### PR TITLE
Fix #7

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -20,6 +20,10 @@ HaystackFilter performs a bitwise `OR` on terms for the same parameters, the
 
 .. class:: drf_haystack.filters.HaystackAutocompleteFilter
 
+By adding a list or tuple of ``ignore_fields`` to the serializer's Meta class,
+we can tell the REST framework to ignore these fields. This is handy in cases,
+where you do not want to serialize and transfer the content of a text, or n-gram
+index down to the client.
 
 An example using the autocomplete filter might look something like this.
 
@@ -31,6 +35,7 @@ An example using the autocomplete filter might look something like this.
         class Meta:
             index_classes = [LocationIndex]
             fields = ["address", "city", "zip_code", "autocomplete"]
+            ignore_fields = ["autocomplete"]
 
             # The `field_aliases` attribute can be used in order to alias a
             # query parameter to a field attribute. In this case a query like

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -46,6 +46,11 @@ Requirements
 Changelog
 =========
 
+1.4
+---
+
+    - A serializer class now accepts a list or tuple of ``ignore_field`` to bypass serialization.
+
 v1.3
 ----
 *Release date: 2015-05-19*

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -87,6 +87,7 @@ class HaystackSerializer(serializers.Serializer):
 
         fields = getattr(self.Meta, "fields", [])
         exclude = getattr(self.Meta, "exclude", [])
+        ignore_fields = getattr(self.Meta, "ignore_fields", [])
 
         declared_fields = copy.deepcopy(self._declared_fields)
 
@@ -106,7 +107,7 @@ class HaystackSerializer(serializers.Serializer):
                                   (field_name, field_type.field_type))
                     continue
 
-                if field_name not in fields or field_name in exclude:
+                if field_name not in fields or field_name in exclude or field_name in ignore_fields:
                     continue
 
                 # Look up the field attributes on the current index model,


### PR DESCRIPTION
Here is the PR for #7

However, I still did not really understand, why it's not possible to simplify ``filters.py`` line 52 into
```
                    if not value:
                        continue
```
This would avoid the added extra field ``ignore_fields`` in the serializers Meta class.