### PR TITLE
allow field lookups in query filters

### DIFF
--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -43,15 +43,18 @@ class HaystackFilter(BaseFilterBackend):
         for param, value in filters.items():
             # Skip if the parameter is not listed in the serializer's `fields`
             # or if it's in the `exclude` list.
+            base_param = param.split("__")[0]  # only test against field without lookup
             if view.serializer_class:
                 try:
                     if hasattr(view.serializer_class.Meta, "field_aliases"):
-                        param = view.serializer_class.Meta.field_aliases.get(param, param)
+                        old_base = base_param
+                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
+                        param = param.replace(old_base, base_param)  # need to replace the alias
 
                     fields = getattr(view.serializer_class.Meta, "fields", [])
                     exclude = getattr(view.serializer_class.Meta, "exclude", [])
 
-                    if param not in fields or param in exclude or not value:
+                    if base_param not in fields or param in exclude or not value:
                         continue
 
                 except AttributeError:

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -83,8 +83,20 @@ class HaystackFilterTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
 
+    def test_filter_single_field_with_lookup(self):
+        request = factory.get(path="/", data={"firstname__startswith": "John"})  # Should return 3 results
+        response = self.view1.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
     def test_filter_aliased_field(self):
         request = factory.get(path="/", data={"name": "John McClane"}, content_type="application/json")
+        response = self.view1.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+    def test_filter_aliased_field_with_lookup(self):
+        request = factory.get(path="/", data={"name__contains": "John McClane"}, content_type="application/json")
         response = self.view1.as_view(actions={"get": "list"})(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 1)


### PR DESCRIPTION
This PR allows the views to accept field lookups in the search query parameters.
e.g. `https://host.com/api/v1/model/search/?field__contains=foobar`

Tests included