### PR TITLE
Fix HaystackSerializer 'fields' and 'exclude' attributes

### DIFF
--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -114,7 +114,7 @@ class HaystackSerializer(serializers.Serializer):
                                   (field_name, field_type.field_type))
                     continue
 
-                if field_name not in fields or field_name in exclude or field_name in ignore_fields:
+                if (not exclude and field_name not in fields) or field_name in exclude or field_name in ignore_fields:
                     continue
 
                 # Look up the field attributes on the current index model,

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -78,6 +78,12 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
             def get_city(self, obj):
                 return "Declared overriding field"
 
+        class Serializer5(HaystackSerializer):
+
+            class Meta:
+                index_classes = [MockPersonIndex]
+                exclude = ["firstname"]
+
         class ViewSet1(HaystackViewSet):
             serializer_class = Serializer3
 
@@ -91,6 +97,7 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         self.serializer2 = Serializer2
         self.serializer3 = Serializer3
         self.serializer4 = Serializer4
+        self.serializer5 = Serializer5
 
         self.view1 = ViewSet1
         self.view2 = ViewSet2
@@ -141,6 +148,17 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         assert isinstance(fields["lastname"], CharField), self.fail("serializer 'lastname' field is not a CharField instance")
         assert isinstance(fields["autocomplete"], CharField), self.fail("serializer 'autocomplete' field is not a CharField instance")
 
+    def test_serializer_get_fields_with_exclude(self):
+        from rest_framework.fields import CharField
+
+        obj = SearchQuerySet().filter(lastname="Foreman")[0]
+        serializer = self.serializer5(instance=obj)
+        fields = serializer.get_fields()
+        assert isinstance(fields, dict), self.fail("serializer.data is not a dict")
+        assert isinstance(fields["text"], CharField), self.fail("serializer 'text' field is not a CharField instance")
+        assert "firstname" not in fields, self.fail("serializer 'firstname' should no be present")
+        assert isinstance(fields["lastname"], CharField), self.fail("serializer 'lastname' field is not a CharField instance")
+        assert isinstance(fields["autocomplete"], CharField), self.fail("serializer 'autocomplete' field is not a CharField instance")
 
 class HaystackViewSetHighlighterTestCase(TestCase):
 
@@ -218,4 +236,3 @@ class HaystackViewSetHighlighterTestCase(TestCase):
                 "%(cls)s is missing a highlighter_class. Define %(cls)s.highlighter_class, "
                 "or override %(cls)s.get_highlighter()." % {"cls": self.viewset3.serializer_class.__name__}
             )
-


### PR DESCRIPTION
This fixes #16.  It includes a test for using the `exclude` attribute