### PR TITLE
Fix multiple index field support

### DIFF
--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -354,3 +354,183 @@ restrictions on the views. This can be overridden on a per-view basis as you wou
         permission_classes = [IsAuthenticated]
 
 
+.. _multiple-search-indexes-label:
+
+
+Reusing Model serializers
+=========================
+
+It may be useful to be able to use existing model serializers to return data from search requests in the same format
+as used elsewhere in your API.  This can be done by modifying the ``to_representation`` method of your serializer to
+use the ``instance.object`` instead of the search result instance.  As a convenience, a mixin class is provided that
+does just that.
+
+.. class:: drf_haystack.serializers.HaystackSerializerMixin
+
+An example using the mixin might look like the following:
+
+.. code-block:: python
+
+    class PersonSerializer(serializers.ModelSerializer):
+        class Meta:
+            model = Person
+            fields = ("id", "firstname", "lastname")
+
+    class PersonSearchSerializer(HaystackSerializerMixin, PersonSerializer):
+        class Meta(PersonSerializer.Meta):
+            search_fields = ("text", )
+
+The results from a search would then contain the fields from the ``PersonSerializer`` rather than fields from the
+search index.
+
+.. note::
+
+    If your model serializer specifies a ``fields`` attribute in its Meta class, then the search serializer must
+    specify a ``search_fields`` attribute in its Meta class if you intend to search on any search index fields
+    that are not in the model serializer fields (e.g. 'text')
+
+.. warning::
+
+    It should be noted that doing this will retrieve the underlying object which means a database hit.  Thus, it will
+    not be as performant as only retrieving data from the search index.  If performance is a concern, it would be
+    better to recreate the desired data structure and store it in the search index.
+
+
+Multiple Search indexes
+=======================
+
+So far, we have only used one class in the ``index_classes`` attribute of our serializers.  However, you are able to specify
+a list of them.  This can be useful when your search engine has indexed multiple models and you want to provide aggregate
+results across two or more of them.  To use the default multiple index support, simply add multiple indexes the ``index_classes``
+list
+
+.. code-block:: python
+
+    class PersonIndex(indexes.SearchIndex, indexes.Indexable):
+        text = indexes.CharField(document=True, use_template=True)
+        firstname = indexes.CharField(model_attr="first_name")
+        lastname = indexes.CharField(model_attr="last_name")
+
+        def get_model(self):
+            return Person
+
+    class PlaceIndex(indexes.SearchIndex, indexes.Indexable):
+        text = indexes.CharField(document=True, use_template=True)
+        address = indexes.CharField(model_attr="address")
+
+        def get_model(self):
+            return Place
+
+    class ThingIndex(indexes.SearchIndex, indexes.Indexable):
+        text = indexes.CharField(document=True, use_template=True)
+        name = indexes.CharField(model_attr="name")
+
+        def get_model(self):
+            return Thing
+
+    class AggregateSerializer(HaystackSerializer):
+
+        class Meta:
+            index_classes = [PersonIndex, PlaceIndex, ThingIndex]
+            fields = ["firstname", "lastname", "address", "name"]
+
+
+    class AggregateSearchViewSet(HaystackViewSet):
+
+        serializer_class = AggregateSerializer
+
+.. note::
+
+    The ``AggregateSearchViewSet class above omits the optional ``index_models`` attribute.  This way results from all the
+    models are returned.
+
+The result from searches using multiple indexes is a list of objects, each of which contains only the fields appropriate to
+the model from which the result came.  For instance if a search returned a list containing one each of the above models, it
+might look like the following:
+
+.. code-block:: javascript
+
+    [
+        {
+            "text": "John Doe",
+            "firstname": "John",
+            "lastname": "Doe"
+        },
+        {
+            "text": "123 Doe Street",
+            "address": "123 Doe Street"
+        },
+        {
+            "text": "Doe",
+            "name": "Doe"
+        }
+    ]
+
+Declared fields
+---------------
+
+You can include field declarations in the serializer class like normal.  Depending on how they are named, they will be
+treated as common fields and added to every result or as specific to results from a particular index.
+
+Common fields are declared as you would any serializer field.  Index-specific fields must be prefixed with "_<index class name>__".
+The following example illustrates this usage:
+
+.. code-block:: python
+
+    class AggregateSerializer(HaystackSerializer):
+        extra = serializers.CharField()
+        _ThingIndex__number = serializers.IntegerField()
+
+        class Meta:
+            index_classes = [PersonIndex, PlaceIndex, ThingIndex]
+            fields = ["firstname", "lastname", "address", "name"]
+
+        def get_extra(self):
+            return "whatever"
+
+        def get__ThingIndex__number(self):
+            return 42
+
+The results of a search might then look like the following:
+
+.. code-block:: javascript
+
+    [
+        {
+            "text": "John Doe",
+            "firstname": "John",
+            "lastname": "Doe",
+            "extra": "whatever"
+        },
+        {
+            "text": "123 Doe Street",
+            "address": "123 Doe Street",
+            "extra": "whatever"
+        },
+        {
+            "text": "Doe",
+            "name": "Doe",
+            "extra": "whatever",
+            "number": 42
+        }
+    ]
+
+Multiple Serializers
+-----------------------
+
+Alternatively, you can specify a 'serializers' attribute on your Meta class to use a different serializer class
+for different indexes as show below:
+
+.. code-block:: python
+
+    class AggregateSearchSerializer(HaystackSerializer):
+        class Meta:
+            serializers = {
+                PersonIndex: PersonSearchSerializer,
+                PlaceIndex: PlaceSearchSerializer,
+                ThingIndex: ThingSearchSerializer
+                }
+
+The ``serializers`` attribute is the important thing here, It's a dictionary with ``SearchIndex`` classes as
+keys and ``Serializer`` classes as values.  Each result in the list of results from a search that contained
+items from multiple indexes would be serialized according to the appropriate serializer.

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -7,6 +7,32 @@ Advanced Usage
 Make sure you've read through the :ref:`basic-usage-label`.
 
 
+Query Field Lookups
+===================
+
+You can also use field lookups in your field queries. See the
+Haystack `field lookups <https://django-haystack.readthedocs.org/en/latest/searchqueryset_api.html?highlight=lookups#id1>`_
+documentation for info on what lookups are available.  A query using a lookup might look like the
+following:
+
+.. code-block:: none
+
+    http://example.com/api/v1/location/search/?city__startswith=Os
+
+This would perform a query looking up all documents where the `city field` started with "Os".
+You might get "Oslo", "Osaka", an "Ostrava".
+
+Query Term Negation
+-------------------
+You can also specify terms to exclude from the search results using the negation keyword.
+The default keyword is "not", but is configurable via settings using ``DRF_HAYSTACK_NEGATION_KEYWORD``.
+
+.. code-block:: none
+
+    http://example.com/api/v1/location/search/?city__not=Oslo
+    http://example.com/api/v1/location/search/?city__not__contains=Los
+    http://example.com/api/v1/location/search/?city__contains=Los&city__not__contains=Angeles
+
 Autocomplete
 ============
 
@@ -122,7 +148,7 @@ from the location with latitude 59.744076 and longitude 10.152045.
 Highlighting
 ============
 
-Haystack supports two kind of `Highlighting <https://django-haystack.readthedocs.org/en/latest/highlighting.html>`_,
+Haystack supports two kinds of `Highlighting <https://django-haystack.readthedocs.org/en/latest/highlighting.html>`_,
 and we support them both.
 
 #. SearchQuerySet highlighting. This kind of highlighting requires a search backend which has support for
@@ -441,7 +467,7 @@ list
 
 .. note::
 
-    The ``AggregateSearchViewSet class above omits the optional ``index_models`` attribute.  This way results from all the
+    The ``AggregateSearchViewSet`` class above omits the optional ``index_models`` attribute.  This way results from all the
     models are returned.
 
 The result from searches using multiple indexes is a list of objects, each of which contains only the fields appropriate to

--- a/drf_haystack/fields.py
+++ b/drf_haystack/fields.py
@@ -1,0 +1,81 @@
+from rest_framework.fields import (
+    BooleanField, CharField, DateField, DateTimeField,
+    DecimalField, FloatField, IntegerField
+)
+
+
+class DRFHaystackFieldMixin(object):
+    prefix_field_names = False
+
+    def __init__(self, **kwargs):
+        self.prefix_field_names = kwargs.pop('prefix_field_names', False)
+        super(DRFHaystackFieldMixin, self).__init__(**kwargs)
+
+    def bind(self, field_name, parent):
+        """
+        Initializes the field name and parent for the field instance.
+        Called when a field is added to the parent serializer instance.
+        Taken from DRF and modified to support drf_haystack multiple index
+        functionality.
+        """
+
+        # In order to enforce a consistent style, we error if a redundant
+        # 'source' argument has been used. For example:
+        # my_field = serializer.CharField(source='my_field')
+        assert self.source != field_name, (
+            "It is redundant to specify `source='%s'` on field '%s' in "
+            "serializer '%s', because it is the same as the field name. "
+            "Remove the `source` keyword argument." %
+            (field_name, self.__class__.__name__, parent.__class__.__name__)
+        )
+
+        self.field_name = field_name
+        self.parent = parent
+
+        # `self.label` should default to being based on the field name.
+        if self.label is None:
+            self.label = field_name.replace('_', ' ').capitalize()
+
+        # self.source should default to being the same as the field name.
+        if self.source is None:
+            self.source = self.convert_field_name(field_name)
+
+        # self.source_attrs is a list of attributes that need to be looked up
+        # when serializing the instance, or populating the validated data.
+        if self.source == '*':
+            self.source_attrs = []
+        else:
+            self.source_attrs = self.source.split('.')
+
+    def convert_field_name(self, field_name):
+        if not self.prefix_field_names:
+            return field_name
+        return field_name.split("__")[-1]
+
+
+class HaystackBooleanField(DRFHaystackFieldMixin, BooleanField):
+    pass
+
+
+class HaystackCharField(DRFHaystackFieldMixin, CharField):
+    pass
+
+
+class HaystackDateField(DRFHaystackFieldMixin, DateField):
+    pass
+
+
+class HaystackDateTimeField(DRFHaystackFieldMixin, DateTimeField):
+    pass
+
+
+class HaystackDecimalField(DRFHaystackFieldMixin, DecimalField):
+    pass
+
+
+class HaystackFloatField(DRFHaystackFieldMixin, FloatField):
+    pass
+
+
+class HaystackIntegerField(DRFHaystackFieldMixin, IntegerField):
+    pass

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -62,7 +62,7 @@ class HaystackFilter(BaseFilterBackend):
                     raise ImproperlyConfigured("%s must implement a Meta class." %
                                                view.serializer_class.__class__.__name__)
 
-            tokens = value.split(view.lookup_sep)
+            tokens = [token.strip() for token in value.split(view.lookup_sep)]
             field_queries = []
 
             for token in tokens:

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -54,8 +54,9 @@ class HaystackFilter(BaseFilterBackend):
 
                     fields = getattr(view.serializer_class.Meta, "fields", [])
                     exclude = getattr(view.serializer_class.Meta, "exclude", [])
+                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
 
-                    if base_param not in fields or param in exclude or not value:
+                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
                         continue
 
                 except AttributeError:

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -37,6 +37,7 @@ class HaystackFilter(BaseFilterBackend):
         """
 
         terms = []
+        exclude_terms = []
 
         if filters is None:
             filters = {}  # pragma: no cover
@@ -44,7 +45,14 @@ class HaystackFilter(BaseFilterBackend):
         for param, value in filters.items():
             # Skip if the parameter is not listed in the serializer's `fields`
             # or if it's in the `exclude` list.
-            base_param = param.split("__")[0]  # only test against field without lookup
+            excluding_term = False
+            param_parts = param.split("__")
+            base_param = param_parts[0]  # only test against field without lookup
+            negation_keyword = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")
+            if len(param_parts) > 1 and param_parts[1] == negation_keyword:
+                excluding_term = True
+                param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
+
             if view.serializer_class:
                 try:
                     if hasattr(view.serializer_class.Meta, "field_aliases"):
@@ -70,15 +78,26 @@ class HaystackFilter(BaseFilterBackend):
                 if token:
                     field_queries.append(view.query_object((param, token)))
 
-            terms.append(six.moves.reduce(operator.or_, filter(lambda x: x, field_queries)))
+            term = six.moves.reduce(operator.or_, filter(lambda x: x, field_queries))
+            if excluding_term:
+                exclude_terms.append(term)
+            else:
+                terms.append(term)
 
-        return six.moves.reduce(operator.and_, filter(lambda x: x, terms)) if terms else []
+        terms = six.moves.reduce(operator.and_, filter(lambda x: x, terms)) if terms else []
+        exclude_terms = six.moves.reduce(operator.and_, filter(lambda x: x, exclude_terms)) if exclude_terms else []
+        return (terms, exclude_terms)
 
     def filter_queryset(self, request, queryset, view):
-        applicable_filters = self.build_filter(view, filters=request.GET.copy())
+        applicable_filters, applicable_exclusions = self.build_filter(view, filters=self.get_request_filters(request))
         if applicable_filters:
             queryset = queryset.filter(applicable_filters)
+        if applicable_exclusions:
+            queryset = queryset.exclude(applicable_exclusions)
         return queryset
+
+    def get_request_filters(self, request):
+        return request.GET.copy()
 
 
 class HaystackAutocompleteFilter(HaystackFilter):
@@ -95,20 +114,25 @@ class HaystackAutocompleteFilter(HaystackFilter):
         single SQ filter using `AND`.
         """
 
-        applicable_filters = self.build_filter(view, filters=request.GET.copy())
+        applicable_filters, applicable_exclusions = self.build_filter(view, filters=self.get_request_filters(request))
 
         if applicable_filters:
-            query_bits = []
-            for field_name, query in applicable_filters.children:
-                for word in query.split(" "):
-                    bit = queryset.query.clean(word.strip())
-                    kwargs = {
-                        field_name: bit
-                    }
-                    query_bits.append(view.query_object(**kwargs))
-            queryset = queryset.filter(six.moves.reduce(operator.and_, filter(lambda x: x, query_bits)))
+            queryset = queryset.filter(self._construct_query(applicable_filters, queryset, view))
+        if applicable_exclusions:
+            queryset = queryset.exclude(self._construct_query(applicable_exclusions, queryset, view))
 
         return queryset
+
+    def _construct_query(self, terms, queryset, view):
+        query_bits = []
+        for field_name, query in terms.children:
+            for word in query.split(" "):
+                bit = queryset.query.clean(word.strip())
+                kwargs = {
+                    field_name: bit
+                }
+                query_bits.append(view.query_object(**kwargs))
+        return six.moves.reduce(operator.and_, filter(lambda x: x, query_bits))
 
 
 class HaystackGEOSpatialFilter(HaystackFilter):

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -15,12 +15,13 @@ from haystack.utils import Highlighter
 
 from rest_framework import serializers
 from rest_framework.compat import OrderedDict
-from rest_framework.fields import (
-    BooleanField, CharField, DateField, DateTimeField,
-    DecimalField, FloatField, IntegerField, empty
-)
+from rest_framework.fields import empty
 from rest_framework.utils.field_mapping import ClassLookupDict, get_field_kwargs
 
+from .fields import (
+    HaystackBooleanField, HaystackCharField, HaystackDateField, HaystackDateTimeField,
+    HaystackDecimalField, HaystackFloatField, HaystackIntegerField
+)
 
 class HaystackSerializer(serializers.Serializer):
     """
@@ -28,34 +29,34 @@ class HaystackSerializer(serializers.Serializer):
     which models that are available in the SearchQueryset.
     """
     _field_mapping = ClassLookupDict({
-        haystack_fields.BooleanField: BooleanField,
-        haystack_fields.CharField: CharField,
-        haystack_fields.DateField: DateField,
-        haystack_fields.DateTimeField: DateTimeField,
-        haystack_fields.DecimalField: DecimalField,
-        haystack_fields.EdgeNgramField: CharField,
-        haystack_fields.FacetBooleanField: BooleanField,
-        haystack_fields.FacetCharField: CharField,
-        haystack_fields.FacetDateField: DateField,
-        haystack_fields.FacetDateTimeField: DateTimeField,
-        haystack_fields.FacetDecimalField: DecimalField,
-        haystack_fields.FacetFloatField: FloatField,
-        haystack_fields.FacetIntegerField: IntegerField,
-        haystack_fields.FacetMultiValueField: CharField,
-        haystack_fields.FloatField: FloatField,
-        haystack_fields.IntegerField: IntegerField,
-        haystack_fields.LocationField: CharField,
-        haystack_fields.MultiValueField: CharField,
-        haystack_fields.NgramField: CharField,
+        haystack_fields.BooleanField: HaystackBooleanField,
+        haystack_fields.CharField: HaystackCharField,
+        haystack_fields.DateField: HaystackDateField,
+        haystack_fields.DateTimeField: HaystackDateTimeField,
+        haystack_fields.DecimalField: HaystackDecimalField,
+        haystack_fields.EdgeNgramField: HaystackCharField,
+        haystack_fields.FacetBooleanField: HaystackBooleanField,
+        haystack_fields.FacetCharField: HaystackCharField,
+        haystack_fields.FacetDateField: HaystackDateField,
+        haystack_fields.FacetDateTimeField: HaystackDateTimeField,
+        haystack_fields.FacetDecimalField: HaystackDecimalField,
+        haystack_fields.FacetFloatField: HaystackFloatField,
+        haystack_fields.FacetIntegerField: HaystackIntegerField,
+        haystack_fields.FacetMultiValueField: HaystackCharField,
+        haystack_fields.FloatField: HaystackFloatField,
+        haystack_fields.IntegerField: HaystackIntegerField,
+        haystack_fields.LocationField: HaystackCharField,
+        haystack_fields.MultiValueField: HaystackCharField,
+        haystack_fields.NgramField: HaystackCharField,
     })
 
     def __init__(self, instance=None, data=empty, **kwargs):
         super(HaystackSerializer, self).__init__(instance, data, **kwargs)
 
         try:
-            if not hasattr(self.Meta, "index_classes"):
-                raise ImproperlyConfigured("You must set the 'index_classes' attribute "
-                                           "on the serializer Meta class.")
+            if not hasattr(self.Meta, "index_classes") and not hasattr(self.Meta, "serializers"):
+                raise ImproperlyConfigured("You must set either the 'index_classes' or 'serializers' "
+                                           "attribute on the serializer Meta class.")
         except AttributeError:
             raise ImproperlyConfigured("%s must implement a Meta class." % self.__class__.__name__)
 
@@ -90,37 +91,43 @@ class HaystackSerializer(serializers.Serializer):
         Get the required fields for serializing the result.
         """
 
-        field_mapping = OrderedDict()
-
         fields = getattr(self.Meta, "fields", [])
         exclude = getattr(self.Meta, "exclude", [])
-        ignore_fields = getattr(self.Meta, "ignore_fields", [])
-
-        declared_fields = copy.deepcopy(self._declared_fields)
 
         if fields and exclude:
             raise ImproperlyConfigured("Cannot set both `fields` and `exclude`.")
 
-        # This has some problems with it. If we're having multiple indexes in
-        # the `index_classes` they might have overlapping attribute names. Here
-        # we currently only support unique field attributes, and the first one
-        # encountered is the only one we'll care about.
-        # TODO: Please fix ;)
-        for index_cls in self.Meta.index_classes:
-            for field_name, field_type in six.iteritems(index_cls.fields):
-                if field_name in field_mapping:
-                    warnings.warn("Field '%s' is already in the field list with field type "
-                                  "'%s'. Will *not* add the field another time." %
-                                  (field_name, field_type.field_type))
-                    continue
+        ignore_fields = getattr(self.Meta, "ignore_fields", [])
+        indices = getattr(self.Meta, "index_classes")
 
-                if (not exclude and field_name not in fields) or field_name in exclude or field_name in ignore_fields:
+        declared_fields = copy.deepcopy(self._declared_fields)
+        prefix_field_names = len(indices) > 1
+        field_mapping = OrderedDict()
+
+
+        # overlapping fields on multiple indices is supported by internally prefixing the field
+        # names with the index class to which they belong or, optionally, a user-provided alias
+        # for the index.
+        for index_cls in self.Meta.index_classes:
+            prefix = ""
+            if prefix_field_names:
+                prefix = "_%s__" % self._get_index_class_name(index_cls)
+            for field_name, field_type in six.iteritems(index_cls.fields):
+                orig_name = field_name
+                field_name = "%s%s" % (prefix, field_name)
+
+                # This has become a little more complex, but provides convenient flexibility for users
+                if not exclude:
+                    if orig_name not in fields and field_name not in fields:
+                        continue
+                elif orig_name in exclude or field_name in exclude or orig_name in ignore_fields or field_name in ignore_fields:
                     continue
 
                 # Look up the field attributes on the current index model,
                 # in order to correctly instantiate the serializer field.
                 model = index_cls().get_model()
                 kwargs = self._get_default_field_kwargs(model, field_type)
+                kwargs['prefix_field_names'] = prefix_field_names
                 field_mapping[field_name] = self._field_mapping[field_type](**kwargs)
 
         # Add any explicitly declared fields. They *will* override any index fields
@@ -131,23 +138,68 @@ class HaystackSerializer(serializers.Serializer):
                     warnings.warn("Field '{field}' already exists in the field list. This *will* "
                                   "overwrite existing field '{field}'".format(field=field_name))
                 field_mapping[field_name] = declared_fields[field_name]
-
         return field_mapping
 
     def to_representation(self, instance):
+        """
+        If we have a serializer mapping, use that.  Otherwise, use standard serializer behavior
+        """
+        serializers = getattr(self.Meta, "serializers", None)
+        if not serializers:
+            return self.default_to_representation(instance)
+
+        index = instance.searchindex
+        serializer_class = serializers.get(type(index), None)
+        if not serializer_class:
+            raise ImproperlyConfigured("Could not find serializer for %s in mapping" % index)
+        return serializer_class(context=self._context).to_representation(instance)
+
+    def default_to_representation(self, instance):
         """
         Since we might be dealing with multiple indexes, some fields might
         not be valid for all results. Do not render the fields which don't belong
         to the search result.
         """
         ret = super(HaystackSerializer, self).to_representation(instance)
+        prefix_field_names = len(getattr(self.Meta, "index_classes")) > 1
+        current_index = self._get_index_class_name(type(instance.searchindex))
         for field in self.fields.keys():
-            if field not in chain(instance.searchindex.fields.keys(), self._declared_fields.keys()):
-                del ret[field]
+            orig_field = field
+            if prefix_field_names:
+                parts = field.split("__")
+                if len(parts) > 1:
+                    index = parts[0][1:]  # trim the preceding '_'
+                    field = parts[1]
+                    if index == current_index:
+                        ret[field] = ret[orig_field]
+                    del ret[orig_field]
+            elif field not in chain(instance.searchindex.fields.keys(), self._declared_fields.keys()):
+                del ret[orig_field]
 
         if hasattr(instance, "highlighted") and instance.highlighted:
             ret["highlighted"] = instance.highlighted[0]
         return ret
+
+    def _get_index_class_name(self, index_cls):
+        """
+        Converts in index model class to a name suitable for use as a field name prefix. A user
+        may optionally specify custom aliases via an 'index_aliases' attribute on the Meta class
+        """
+        cls_name = str(index_cls).replace("<class '", "").replace("'>", "")
+        aliases = getattr(self.Meta, "index_aliases", {})
+        return aliases.get(cls_name, cls_name.split('.')[-1])
+
+
+class HaystackSerializerMixin(object):
+    """
+    This mixin can be added to a rerializer to use the actual object as the data source for serialization rather
+    than the data stored in the search index fields.  This makes it easy to return data from search results in
+    the same format as elswhere in your API and reuse your existing serializers
+    """
+
+    def to_representation(self, instance):
+        obj = instance.object
+        return super(HaystackSerializerMixin, self).to_representation(obj)
 
 
 class HighlighterMixin(object):

--- a/tests/mockapp/fixtures/mockpet.json
+++ b/tests/mockapp/fixtures/mockpet.json
@@ -1,0 +1,102 @@
+[
+{
+  "pk": 1,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "John",
+    "created": "2015-05-19T10:48:08.686Z",
+    "species": "Iguana",
+    "updated": "2015-05-19T10:48:08.686Z"
+  }
+},
+{
+  "pk": 2,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Fido",
+    "created": "2015-05-19T10:48:08.688Z",
+    "species": "Dog",
+    "updated": "2015-05-19T10:48:08.688Z"
+  }
+},
+{
+  "pk": 3,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Zane",
+    "created": "2015-05-19T10:48:08.689Z",
+    "species": "Dog",
+    "updated": "2015-05-19T10:48:08.689Z"
+  }
+},
+{
+  "pk": 4,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Spot",
+    "created": "2015-05-19T10:48:08.690Z",
+    "species": "Dog",
+    "updated": "2015-05-19T10:48:08.690Z"
+  }
+},
+{
+  "pk": 5,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Sam",
+    "created": "2015-05-19T10:48:08.691Z",
+    "species": "Bird",
+    "updated": "2015-05-19T10:48:08.691Z"
+  }
+},
+{
+  "pk": 6,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Jenny",
+    "created": "2015-05-19T10:48:08.693Z",
+    "species": "Cat",
+    "updated": "2015-05-19T10:48:08.693Z"
+  }
+},
+{
+  "pk": 7,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Mr. Squiggles",
+    "created": "2015-05-19T10:48:08.694Z",
+    "species": "Cat",
+    "updated": "2015-05-19T10:48:08.694Z"
+  }
+},
+{
+  "pk": 8,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Mrs. Buttersworth",
+    "created": "2015-05-19T10:48:08.695Z",
+    "species": "Dog",
+    "updated": "2015-05-19T10:48:08.695Z"
+  }
+},
+{
+  "pk": 9,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Tweety",
+    "created": "2015-05-19T10:48:08.696Z",
+    "species": "Bird",
+    "updated": "2015-05-19T10:48:08.696Z"
+  }
+},
+{
+  "pk": 10,
+  "model": "mockapp.mockpet",
+  "fields": {
+    "name": "Jake",
+    "created": "2015-05-19T10:48:08.697Z",
+    "species": "Cat",
+    "updated": "2015-05-19T10:48:08.697Z"
+  }
+}
+]

--- a/tests/mockapp/migrations/0003_mockpet.py
+++ b/tests/mockapp/migrations/0003_mockpet.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('mockapp', '0001_initial'),
+        ('mockapp', '0002_mockperson'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='MockPet',
+            fields=[
+                ('id', models.AutoField(auto_created=True, verbose_name='ID', primary_key=True, serialize=False)),
+                ('name', models.CharField(max_length=20)),
+                ('species', models.CharField(max_length=20)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('updated', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+            },
+            bases=(models.Model,),
+        ),
+    ]

--- a/tests/mockapp/migrations/0004_load_fixtures.py
+++ b/tests/mockapp/migrations/0004_load_fixtures.py
@@ -9,7 +9,7 @@ from django.db import models, migrations
 
 def load_data(apps, schema_editor):
     """
-    Load fixtures for MockPerson and MockLocation
+    Load fixtures for MockPerson, MockPet and MockLocation
     """
 
     fixtures = os.path.abspath(os.path.join(os.path.dirname(__file__), os.path.pardir, "fixtures"))
@@ -24,16 +24,23 @@ def load_data(apps, schema_editor):
         for obj in objects:
             obj.save()
 
+    with open(os.path.join(fixtures, "mockpet.json"), "r") as fixture:
+        objects = serializers.deserialize("json", fixture, ignorenonexistent=True)
+        for obj in objects:
+            obj.save()
+
 def unload_data(apps, schema_editor):
     """
-    Unload fixtures for MockPerson and MockLocation
+    Unload fixtures for MockPerson, MockPet and MockLocation
     """
 
     MockPerson = apps.get_model("mockapp", "MockPerson")
     MockLocation = apps.get_model("mockapp", "MockLocation")
+    MockPet = apps.get_model("mockapp", "MockPet")
 
     MockPerson.objects.all().delete()
     MockLocation.objects.all().delete()
+    MockPet.objects.all().delete()
 
 
 class Migration(migrations.Migration):
@@ -41,6 +48,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ("mockapp", "0001_initial"),
         ("mockapp", "0002_mockperson"),
+        ("mockapp", "0003_mockpet"),
     ]
 
     operations = [

--- a/tests/mockapp/models.py
+++ b/tests/mockapp/models.py
@@ -42,3 +42,16 @@ class MockPerson(models.Model):
 
     def __str__(self):
         return "%s %s" % (self.firstname, self.lastname)
+
+
+@python_2_unicode_compatible
+class MockPet(models.Model):
+
+    name = models.CharField(max_length=20)
+    species = models.CharField(max_length=20)
+
+    created = models.DateTimeField(auto_now_add=True)
+    updated = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.name

--- a/tests/mockapp/search_indexes.py
+++ b/tests/mockapp/search_indexes.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import, unicode_literals
 from django.utils import timezone
 from haystack import indexes
 
-from .models import MockLocation, MockPerson
+from .models import MockLocation, MockPerson, MockPet
 
 
 class MockLocationIndex(indexes.SearchIndex, indexes.Indexable):
@@ -62,3 +62,24 @@ class MockPersonIndex(indexes.SearchIndex, indexes.Indexable):
         return self.get_model().objects.filter(
             created__lte=timezone.now()
         )
+
+
+class MockPetIndex(indexes.SearchIndex, indexes.Indexable):
+
+    text = indexes.CharField(document=True, use_template=True)
+    name = indexes.CharField(model_attr="name")
+    species = indexes.CharField(model_attr="species")
+    description = indexes.CharField()
+
+    autocomplete = indexes.EdgeNgramField()
+
+    @staticmethod
+    def prepare_description(obj):
+        return " ".join((obj.name, "the", obj.species))
+
+    @staticmethod
+    def prepare_autocomplete(obj):
+        return obj.name
+
+    def get_model(self):
+        return MockPet

--- a/tests/mockapp/templates/search/indexes/mockapp/mockpet_text.txt
+++ b/tests/mockapp/templates/search/indexes/mockapp/mockpet_text.txt
@@ -1,0 +1,1 @@
+{{ object.name }}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -164,6 +164,23 @@ class HaystackFilterTestCase(TestCase):
         response = self.view1.as_view(actions={"get": "list"})(request)
         self.assertEqual(len(response.data), 1)
 
+    def test_filter_negated_field(self):
+        request = factory.get(path="/", data={"text__not": "John"}, content_type="application/json")
+        response = self.view1.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 97)
+
+    def test_filter_negated_field_with_lookup(self):
+        request = factory.get(path="/", data={"name__not__contains": "John McClane"}, content_type="application/json")
+        response = self.view1.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 99)
+
+    def test_filter_negated_field_with_other_field(self):
+        request = factory.get(path="/", data={"firstname": "John", "lastname__not": "McClane"}, content_type="application/json")
+        response = self.view1.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
 class HaystackAutocompleteFilterTestCase(TestCase):
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -143,6 +143,12 @@ class HaystackFilterTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), MOCKPERSON_DATA_SET_SIZE)  # Should return all results since, field is ignored
 
+    def test_filter_with_non_searched_excluded_field(self):
+        request = factory.get(path="/", data={"text": "John"}, content_type="application/json")
+        response = self.view2.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
+
     def test_filter_raise_on_serializer_without_meta_class(self):
         # Make sure we're getting an ImproperlyConfigured when trying to filter on a viewset
         # with a serializer without `Meta` class.

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -258,19 +258,33 @@ class HaystackSerializerMultipleIndexTestCase(WarningTestCaseMixin, TestCase):
         serializer = self.serializer1(instance=objs, many=True)
         data = serializer.data
         assert len(data) == 4, self.fail("all objects are not present")
-        assert "name" in data[0], self.fail("'name' should be present in Pet results")
-        assert "species" in data[0], self.fail("'species' should be present in Pet results")
-        assert "firstname" in data[1], self.fail("'firstname' should be present in Person results")
-        assert "lastname" in data[1], self.fail("'lastname' should be present in Person results")
+        for result in data:
+            if "name" in result:
+                assert "species" in result, self.fail("Pet results should have 'species' and 'name' fields")
+                assert "firstname" not in result, self.fail("Pet results should have 'species' and 'name' fields")
+                assert "lastname" not in result, self.fail("Pet results should have 'species' and 'name' fields")
+            elif "firstname" in result:
+                assert "lastname" in result, self.fail("Person results should have 'firstname' and 'lastname' fields")
+                assert "name" not in result, self.fail("Person results should have 'firstname' and 'lastname' fields")
+                assert "species" not in result, self.fail("Person results should have 'firstname' and 'lastname' fields")
+            else:
+                self.fail("Result should contain either Pet or Person fields")
 
     def test_serializer_multiple_index_declared_fields(self):
         objs = SearchQuerySet().filter(text="John")
         serializer = self.serializer2(instance=objs, many=True)
         data = serializer.data
-        assert "extra" in data[0], self.fail("'extra' should be present in Pet results")
-        assert "hair_color" not in data[0], self.fail("'hair_color' should not be present in Pet results")
-        assert "extra" in data[1], self.fail("'extra' should be present in Person results")
-        assert "hair_color" in data[1], self.fail("'hair_color' should be present in Person results")
+        assert len(data) == 4, self.fail("all objects are not present")
+        for result in data:
+            if "name" in result:
+                assert "extra" in result, self.fail("'extra' should be present in Pet results")
+                assert "hair_color" not in result, self.fail("'hair_color' should not be present in Pet results")
+            elif "firstname" in result:
+                assert "extra" in result, self.fail("'extra' should be present in Person results")
+                assert "hair_color" in result, self.fail("'hair_color' should be present in Person results")
+            else:
+                self.fail("Result should contain either Pet or Person fields")
+
 
 class HaystackSerializerHighlighterMixinTestCase(WarningTestCaseMixin, TestCase):
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -279,7 +279,7 @@ class HaystackSerializerMultipleIndexTestCase(WarningTestCaseMixin, TestCase):
             if "name" in result:
                 assert "extra" in result, self.fail("'extra' should be present in Pet results")
                 assert "hair_color" not in result, self.fail("'hair_color' should not be present in Pet results")
-            elif "firstname" in result:
+            elif "lastname" in result:
                 assert "extra" in result, self.fail("'extra' should be present in Person results")
                 assert "hair_color" in result, self.fail("'hair_color' should be present in Person results")
             else:


### PR DESCRIPTION
Okay, this ended up being more involved than I originally thought, but here's a PR with enhanced support for using multiple indexes.  I'll describe the following major pieces below:
* Automatic Multiple Index Field Handling
* Ability to Use Multiple Serializers
* Serializer Mixin
* Miscellaneous

## Automatic Multiple Index Field Handling

The original problem that needed to be solved was that if you used multiple indexes that had overlapping field names, only one field would be used.  If they happened to be different field types, that would be a big problem.

The code in this PR internally modifies the field names to associate them with a specific index.  Let's say we have the following setup:

```python
class Index1(indexes.searchIndex, indexes.Indexable):
    text = indexes.CharField(document=True, use_template=True)
    my_field = indexes.CharField()
    ...

class Index2(indexes.searchIndex, indexes.Indexable):
    text = indexes.CharField(document=True, use_template=True)
    my_field = indexes.IntegerField()
    ...

class MySerializer(HaystackSerializer):
    class Meta:
        index_classes = [Index1, Index2]
```

Internally, the fields will be given the following names:
* `_Index1__text`
* `_Index2__text`
* `_Index1__my_field`
* `_Index2__my_field`

Thus, no overlap issues occur.  The field names are converted back during serialization so the handling is transparent to the user.  To make this work, the classes in the `_field_mapping` had to be replaced with proxy versions that handle the renaming

## Ability to Use Multiple Serializers

As an alternative to the automatic handling above, a user may choose to specify a dictionary of Index:Serializer mappings to user a separate serializer of his or her choosing for each index.  Let's say we also have:

```python
class Serializer1(serializers.Serializer):
    ...

class Serializer2(serializers.Serializer):
    ...

class MySerializer2(HaystackSerializer):
    class Meta:
        serializers = {
            Index1: Serializer1,
            Index2: Serializer2
        }
```

Each result will be serialized by the appropriate serializer.  `serializers` takes precedent if `index_classes` is also specified.

## Serializer Mixin

A `HaystackSerializerMixin` class is provided as convenience to easily reuse existing model serializers.  This can be desireable if you want to return the same data formats from your search APIs that you do from your other APIs and have complex formats that you don't want to recreate with search indexes.  And if you don't mind the performance hit.  We might have something like:

```python
class Model1Serializer(serializers.ModelSerializer):
    ...

class Model2Serializer(serializers.ModelSerializer):
    ...

class Model1SearchSerializer(HaystackSerializerMixin, Model1Serializer):
    pass

class Model2SearchSerializer(HaystackSerializerMixin, Model2Serializer):
    pass

class MySerializer3(HaystackSerializer):
    class Meta:
        serializers = {
            Index1: Model1SearchSerializer,
            Index2: Model2SearchSerializer
        }
```

## Miscellaneous

This PR comes with updated tests and documentation, as well, including a migration and fixture for a third mock model (MockPet) in the test app.  

Moving forward, I'm considering adding an option to have the serializer automatically inject a 'type' field or the like, to more readily facilitate post-processing of the results list (e.g. separating out results by type), but for the time being users can achieve this themselves by adding something to their serializers or indexes