### PR TITLE
Moved filter query building logic and added meta classes to handle integrity of serializers

### DIFF
--- a/drf_haystack/constants.py
+++ b/drf_haystack/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+DRF_HAYSTACK_NEGATION_KEYWORD = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -6,7 +6,6 @@ import operator
 import warnings
 from itertools import chain
 
-from dateutil import parser
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -17,7 +16,7 @@ from haystack.query import SearchQuerySet
 
 from rest_framework.filters import BaseFilterBackend
 
-from .utils import merge_dict
+from .query import QueryBuilder
 
 
 class HaystackFilter(BaseFilterBackend):
@@ -26,12 +25,14 @@ class HaystackFilter(BaseFilterBackend):
     filtering query.
     """
 
+    query_builder = QueryBuilder()
+
     @staticmethod
     def get_request_filters(request):
         return request.GET.copy()
 
-    @staticmethod
-    def build_filter(view, filters=None):
+    @classmethod
+    def build_filter(cls, view, filters=None):
         """
         Creates a single SQ filter from querystring parameters that
         correspond to the SearchIndex fields that have been "registered"
@@ -43,58 +44,7 @@ class HaystackFilter(BaseFilterBackend):
         Any querystring parameters that are not registered in
         `view.fields` will be ignored.
         """
-
-        terms = []
-        exclude_terms = []
-
-        if filters is None:
-            filters = {}  # pragma: no cover
-
-        for param, value in filters.items():
-            # Skip if the parameter is not listed in the serializer's `fields`
-            # or if it's in the `exclude` list.
-            excluding_term = False
-            param_parts = param.split("__")
-            base_param = param_parts[0]  # only test against field without lookup
-            negation_keyword = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")
-            if len(param_parts) > 1 and param_parts[1] == negation_keyword:
-                excluding_term = True
-                param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
-
-            if view.serializer_class:
-                try:
-                    if hasattr(view.serializer_class.Meta, "field_aliases"):
-                        old_base = base_param
-                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
-                        param = param.replace(old_base, base_param)  # need to replace the alias
-
-                    fields = getattr(view.serializer_class.Meta, "fields", [])
-                    exclude = getattr(view.serializer_class.Meta, "exclude", [])
-                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
-
-                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
-                        continue
-
-                except AttributeError:
-                    raise ImproperlyConfigured("%s must implement a Meta class." %
-                                               view.serializer_class.__class__.__name__)
-
-            tokens = [token.strip() for token in value.split(view.lookup_sep)]
-            field_queries = []
-
-            for token in tokens:
-                if token:
-                    field_queries.append(view.query_object((param, token)))
-
-            term = six.moves.reduce(operator.or_, filter(lambda x: x, field_queries))
-            if excluding_term:
-                exclude_terms.append(term)
-            else:
-                terms.append(term)
-
-        terms = six.moves.reduce(operator.and_, filter(lambda x: x, terms)) if terms else []
-        exclude_terms = six.moves.reduce(operator.and_, filter(lambda x: x, exclude_terms)) if exclude_terms else []
-        return terms, exclude_terms
+        return cls.query_builder.build_query(view, **(filters if filters else {}))
 
     def filter_queryset(self, request, queryset, view):
         applicable_filters, applicable_exclusions = self.build_filter(view, filters=self.get_request_filters(request))
@@ -289,93 +239,12 @@ class HaystackFacetFilter(HaystackFilter):
 
     # TODO: Support multiple indexes/serializers
 
-    @staticmethod
-    def parse(lookup_sep, options):
-        """
-        Parse the field options query string and return it as a dictionary.
-        """
-        defaults = {}
-        if isinstance(options, six.text_type):
-
-            tokens = [token.strip() for token in options.split(lookup_sep)]
-
-            for token in tokens:
-                if not len(token.split(":")) == 2:
-                    warnings.warn("The %s token is not properly formatted. Tokens need to be "
-                                  "formatted as 'token:value' pairs." % token)
-                    continue
-
-                param, value = token.split(":")
-
-                if any([k == param for k in ("start_date", "end_date", "gap_amount")]):
-
-                    if param in ("start_date", "end_date"):
-                        value = parser.parse(value)
-
-                    if param == "gap_amount":
-                        value = int(value)
-
-                defaults[param] = value
-
-        return defaults
-
     def build_facet_filter(self, view, filters=None):
         """
         Creates a dict of dictionaries suitable for passing to the
         SearchQuerySet ``facet``, ``date_facet`` or ``query_facet`` method.
         """
-
-        field_facets = {}
-        date_facets = {}
-        query_facets = {}
-        facet_serializer_cls = view.get_facet_serializer_class()
-
-        if filters is None:
-            filters = {}  # pragma: no cover
-
-        if view.lookup_sep == ":":
-            raise AttributeError("The %(cls)s.lookup_sep attribute conflicts with the HaystackFacetFilter "
-                                 "query parameter parser. Please choose another `lookup_sep` attribute "
-                                 "for %(cls)s." % {"cls": view.__class__.__name__})
-
-        try:
-            fields = getattr(facet_serializer_cls.Meta, "fields", [])
-            exclude = getattr(facet_serializer_cls.Meta, "exclude", [])
-            field_options = getattr(facet_serializer_cls.Meta, "field_options", {})
-
-            for field, options in filters.items():
-
-                if field not in fields or field in exclude:
-                    continue
-
-                field_options = merge_dict(field_options, {field: self.parse(view.lookup_sep, options)})
-
-            valid_gap = ("year", "month", "day", "hour", "minute", "second")
-            for field, options in field_options.items():
-                if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
-
-                    if not all(("start_date", "end_date", "gap_by" in options)):
-                        raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
-                                         "and 'gap_by' to be set.")
-
-                    if not options["gap_by"] in valid_gap:
-                        raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
-
-                    options.setdefault("gap_amount", 1)
-                    date_facets[field] = field_options[field]
-
-                else:
-                    field_facets[field] = field_options[field]
-
-        except AttributeError:
-            raise ImproperlyConfigured("%s must implement a Meta class." %
-                                       facet_serializer_cls.__class__.__name__)
-
-        return {
-            "date_facets": date_facets,
-            "field_facets": field_facets,
-            "query_facets": query_facets
-        }
+        return self.query_builder.build_facet_query(view, **(filters if filters else {}))
 
     @staticmethod
     def apply_facets(queryset, filters):

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -1,0 +1,177 @@
+import operator
+import warnings
+from itertools import chain
+
+import six
+from dateutil import parser
+from django.core.exceptions import ImproperlyConfigured
+from drf_haystack.utils import merge_dict
+from . import constants
+
+
+class QueryBuilder:
+
+    """
+    Builds query parameters for haystack filters.
+    """
+
+    def build_query(self, view, **kwargs):
+        """
+        Creates a single SQ filter from querystring parameters that correspond to the SearchIndex fields
+        that have been "registered" in `view.fields`.
+
+        Default behavior is to `OR` terms for the same parameters, and `AND` between parameters. Any
+        querystring parameters that are not registered in `view.fields` will be ignored.
+
+        :param view:
+        :param dict[str, list[str]] kwargs: is an expanded QueryDict or a mapping of keys to a list of
+        parameters.
+        """
+
+        terms = []
+        exclude_terms = []
+
+        for param, value in kwargs.items():
+            # Skip if the parameter is not listed in the serializer's `fields`
+            # or if it's in the `exclude` list.
+            excluding_term = False
+            param_parts = param.split("__")
+            base_param = param_parts[0]  # only test against field without lookup
+            negation_keyword = constants.DRF_HAYSTACK_NEGATION_KEYWORD
+            if len(param_parts) > 1 and param_parts[1] == negation_keyword:
+                excluding_term = True
+                param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
+
+            if view.serializer_class:
+                try:
+                    if hasattr(view.serializer_class.Meta, "field_aliases"):
+                        old_base = base_param
+                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
+                        param = param.replace(old_base, base_param)  # need to replace the alias
+
+                    fields = getattr(view.serializer_class.Meta, "fields", [])
+                    exclude = getattr(view.serializer_class.Meta, "exclude", [])
+                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
+
+                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
+                        continue
+
+                except AttributeError:
+                    raise ImproperlyConfigured("%s must implement a Meta class." %
+                                               view.serializer_class.__class__.__name__)
+
+            field_queries = []
+            for token in self.tokenize(value, view.lookup_sep):
+                field_queries.append(view.query_object((param, token)))
+
+            term = six.moves.reduce(operator.or_, filter(lambda x: x, field_queries))
+            if excluding_term:
+                exclude_terms.append(term)
+            else:
+                terms.append(term)
+
+        terms = six.moves.reduce(operator.and_, filter(lambda x: x, terms)) if terms else []
+        exclude_terms = six.moves.reduce(operator.and_, filter(lambda x: x, exclude_terms)) if exclude_terms else []
+        return terms, exclude_terms
+
+    def build_facet_query(self, view, **kwargs):
+        """
+        Creates a dict of dictionaries suitable for passing to the SearchQuerySet ``facet``, ``date_facet``
+        or ``query_facet`` method. All key word arguments should be wrapped in a list.
+
+        :param view:
+        :param dict[str, list[str]] kwargs: is an expanded QueryDict or a mapping of keys to a list of
+        parameters.
+        """
+        field_facets = {}
+        date_facets = {}
+        query_facets = {}
+        facet_serializer_cls = view.get_facet_serializer_class()
+
+        if view.lookup_sep == ":":
+            raise AttributeError("The %(cls)s.lookup_sep attribute conflicts with the HaystackFacetFilter "
+                                 "query parameter parser. Please choose another `lookup_sep` attribute "
+                                 "for %(cls)s." % {"cls": view.__class__.__name__})
+
+        try:
+            fields = getattr(facet_serializer_cls.Meta, "fields", [])
+            exclude = getattr(facet_serializer_cls.Meta, "exclude", [])
+            field_options = getattr(facet_serializer_cls.Meta, "field_options", {})
+
+            for field, options in kwargs.items():
+
+                if field not in fields or field in exclude:
+                    continue
+
+                field_options = merge_dict(field_options, {field: self.parse_field_options(view.lookup_sep, *options)})
+
+            valid_gap = ("year", "month", "day", "hour", "minute", "second")
+            for field, options in field_options.items():
+                if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
+
+                    if not all(("start_date", "end_date", "gap_by" in options)):
+                        raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
+                                         "and 'gap_by' to be set.")
+
+                    if not options["gap_by"] in valid_gap:
+                        raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
+
+                    options.setdefault("gap_amount", 1)
+                    date_facets[field] = field_options[field]
+
+                else:
+                    field_facets[field] = field_options[field]
+
+        except AttributeError:
+            raise ImproperlyConfigured("%s must implement a Meta class." %
+                                       facet_serializer_cls.__class__.__name__)
+
+        return {
+            "date_facets": date_facets,
+            "field_facets": field_facets,
+            "query_facets": query_facets
+        }
+
+    def build_geo_query(self, view, filters):
+        pass
+
+    def tokenize(self, stream, seperator):
+        """
+        Tokenizes a value into
+        :param stream:
+        :param seperator:
+        :return:
+        """
+        for value in stream:
+            for token in value.split(seperator):
+                if token:
+                    yield token.strip()
+
+    def parse_field_options(self, lookup_sep, *options):
+        """
+        Parse the field options query string and return it as a dictionary.
+        """
+        defaults = {}
+        for option in options:
+            if isinstance(option, six.text_type):
+                tokens = [token.strip() for token in option.split(lookup_sep)]
+
+                for token in tokens:
+                    if not len(token.split(":")) == 2:
+                        warnings.warn("The %s token is not properly formatted. Tokens need to be "
+                                      "formatted as 'token:value' pairs." % token)
+                        continue
+
+                    param, value = token.split(":")
+
+                    if any([k == param for k in ("start_date", "end_date", "gap_amount")]):
+
+                        if param in ("start_date", "end_date"):
+                            value = parser.parse(value)
+
+                        if param == "gap_amount":
+                            value = int(value)
+
+                    defaults[param] = value
+
+        return defaults

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -132,8 +132,8 @@ class QueryBuilder:
             "query_facets": query_facets
         }
 
-    def build_geo_query(self, view, filters):
-        pass
+    def build_geo_query(self, view, **kwargs):
+        raise NotImplemented("GEO Queries are currently handled by subclassing BaseHaystackGEOSpatialFilter")
 
     def tokenize(self, stream, seperator):
         """

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -48,7 +48,7 @@ class Meta(type):
     index_aliases = {}
 
     def __new__(mcs, name, bases, attrs):
-        cls = super().__new__(mcs, name, bases, attrs)
+        cls = super(Meta, mcs).__new__(mcs, name, bases, attrs)
 
         if cls.fields and cls.exclude:
             raise ImproperlyConfigured("%s cannot define fields and exclude" % name)

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,7 +96,7 @@ LOGGING = {
     'loggers': {
         'default': {
             'handlers': ['file_handler'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': True,
         },
         'elasticsearch': {

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -155,15 +155,6 @@ class HaystackFilterTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
 
-    def test_filter_raise_on_serializer_without_meta_class(self):
-        # Make sure we're getting an ImproperlyConfigured when trying to filter on a viewset
-        # with a serializer without `Meta` class.
-        request = factory.get(path="/", data={"lastname": "Hood"}, content_type="application/json")
-        self.assertRaises(
-            ImproperlyConfigured,
-            self.view3.as_view(actions={"get": "list"}), request
-        )
-
     def test_filter_unicode_characters(self):
         request = factory.get(path="/", data={"firstname": "åsmund", "lastname": "sørensen"},
                               content_type="application/json")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -8,11 +8,11 @@ from __future__ import absolute_import, unicode_literals
 import json
 from datetime import datetime, timedelta
 
+import six
 from django.conf.urls import url, include
 from django.core.exceptions import ImproperlyConfigured
 from django.http import QueryDict
-from django.test import TestCase
-
+from django.test import TestCase, SimpleTestCase
 from haystack.query import SearchQuerySet
 
 from rest_framework import serializers
@@ -23,8 +23,8 @@ from rest_framework.test import APIRequestFactory, APITestCase
 from drf_haystack.generics import SQHighlighterMixin
 from drf_haystack.serializers import (
     HighlighterMixin, HaystackSerializer,
-    HaystackSerializerMixin, HaystackFacetSerializer
-)
+    HaystackSerializerMixin, HaystackFacetSerializer,
+    HaystackSerializerMeta)
 from drf_haystack.viewsets import HaystackViewSet
 
 from .mixins import WarningTestCaseMixin
@@ -92,26 +92,6 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         MockPetIndex().reindex()
 
         class Serializer1(HaystackSerializer):
-            # This is not allowed. Serializer must implement a
-            # `Meta` class
-            pass
-
-        class Serializer2(HaystackSerializer):
-
-            class Meta:
-                # This is not allowed. The Meta class must implement
-                # a `index_classes` attribute
-                pass
-
-        class Serializer3(HaystackSerializer):
-
-            class Meta:
-                index_classes = [MockPersonIndex]
-                fields = ["some_field"]
-                exclude = ["another_field"]
-                # This is not allowed. Can't set both `fields` and `exclude`
-
-        class Serializer4(HaystackSerializer):
 
             integer_field = serializers.IntegerField()
             city = serializers.CharField()
@@ -126,13 +106,13 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
             def get_city(self, obj):
                 return "Declared overriding field"
 
-        class Serializer5(HaystackSerializer):
+        class Serializer2(HaystackSerializer):
 
             class Meta:
                 index_classes = [MockPersonIndex]
                 exclude = ["firstname"]
 
-        class Serializer6(HaystackSerializer):
+        class Serializer3(HaystackSerializer):
 
             class Meta:
                 index_classes = [MockPersonIndex]
@@ -145,10 +125,7 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
                 index_classes = [MockPetIndex]
 
         class ViewSet1(HaystackViewSet):
-            serializer_class = Serializer3
-
-        class ViewSet2(HaystackViewSet):
-            serializer_class = Serializer4
+            serializer_class = Serializer1
 
             class Meta:
                 index_models = [MockPerson]
@@ -156,44 +133,22 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         self.serializer1 = Serializer1
         self.serializer2 = Serializer2
         self.serializer3 = Serializer3
-        self.serializer4 = Serializer4
-        self.serializer5 = Serializer5
-        self.serializer6 = Serializer6
         self.serializer7 = Serializer7
-
         self.view1 = ViewSet1
-        self.view2 = ViewSet2
 
     def tearDown(self):
         MockPersonIndex().clear()
 
     def test_serializer_raise_without_meta_class(self):
         try:
-            self.serializer1()
-            self.fail("Did not fail when initialized serializer with no Meta class")
+            class Serializer(HaystackSerializer):
+                pass
+            self.fail("Did not fail when defining a Serializer without a Meta class")
         except ImproperlyConfigured as e:
-            self.assertEqual(str(e), "%s must implement a Meta class." % self.serializer1.__name__)
-
-    def test_serializer_raise_without_index_models(self):
-        try:
-            self.serializer2()
-            self.fail("Did not fail when initialized serializer with no 'index_classes' attribute")
-        except ImproperlyConfigured as e:
-            self.assertEqual(str(e), "You must set either the 'index_classes' or 'serializers' "
-                                     "attribute on the serializer Meta class.")
-
-    def test_serializer_raise_on_both_fields_and_exclude(self):
-        # Make sure we're getting an ImproperlyConfigured when trying to call a viewset
-        # which has both `fields` and `exclude` set.
-        request = factory.get(path="/", data="", content_type="application/json")
-        try:
-            self.view1.as_view(actions={"get": "list"})(request)
-            self.fail("Did not fail when serializer has both 'fields' and 'exclude' attributes")
-        except ImproperlyConfigured as e:
-            self.assertEqual(str(e), "Cannot set both `fields` and `exclude`.")
+            self.assertEqual(str(e), "%s must implement a Meta class or have the property _abstract" % "Serializer")
 
     def test_serializer_gets_default_instance(self):
-        serializer = self.serializer4(instance=None)
+        serializer = self.serializer1(instance=None)
         assert isinstance(serializer.instance, SearchQuerySet), self.fail("Did not get default instance "
                                                                           "of type SearchQuerySet")
 
@@ -201,7 +156,7 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         from rest_framework.fields import CharField, IntegerField
 
         obj = SearchQuerySet().filter(lastname="Foreman")[0]
-        serializer = self.serializer4(instance=obj)
+        serializer = self.serializer1(instance=obj)
         fields = serializer.get_fields()
         assert isinstance(fields, dict), self.fail("serializer.data is not a dict")
         assert isinstance(fields["integer_field"], IntegerField), self.fail("serializer 'integer_field' field is not a IntegerField instance")
@@ -214,7 +169,7 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         from rest_framework.fields import CharField
 
         obj = SearchQuerySet().filter(lastname="Foreman")[0]
-        serializer = self.serializer5(instance=obj)
+        serializer = self.serializer2(instance=obj)
         fields = serializer.get_fields()
         assert isinstance(fields, dict), self.fail("serializer.data is not a dict")
         assert isinstance(fields["text"], CharField), self.fail("serializer 'text' field is not a CharField instance")
@@ -226,7 +181,7 @@ class HaystackSerializerTestCase(WarningTestCaseMixin, TestCase):
         from rest_framework.fields import CharField
 
         obj = SearchQuerySet().filter(lastname="Foreman")[0]
-        serializer = self.serializer6(instance=obj)
+        serializer = self.serializer3(instance=obj)
         fields = serializer.get_fields()
         assert isinstance(fields, dict), self.fail("serializer.data is not a dict")
         assert isinstance(fields["text"], CharField), self.fail("serializer 'text' field is not a CharField instance")
@@ -466,34 +421,6 @@ class HaystackFacetSerializerTestCase(TestCase):
             format=json
         )
 
-        class FacetSerializer(HaystackFacetSerializer):
-
-            serialize_objects = True
-
-            class Meta:
-                fields = ["firstname", "lastname"]
-                field_options = {
-                    "firstname": {},
-                    "lastname": {}
-                }
-
-        class Serializer(HaystackSerializer):
-
-            class Meta:
-                index_classes = [MockPersonIndex]
-                fields = ["firstname", "lastname", "full_name"]
-
-        class ViewSet(HaystackViewSet):
-
-            serializer_class = Serializer
-            facet_serializer_class = FacetSerializer
-            pagination_class = PageNumberPagination
-
-            class Meta:
-                index_models = [MockPerson]
-
-        self.view = ViewSet
-
     def tearDown(self):
         MockPersonIndex().clear()
 
@@ -619,6 +546,13 @@ class HaystackFacetSerializerTestCase(TestCase):
         firstname = fields["firstname"][0]
         self.assertFalse("page=2" in firstname["narrow_url"])
 
+    def test_serializer_raise_without_meta_class(self):
+        try:
+            class FacetSerializer(HaystackFacetSerializer):
+                pass
+            self.fail("Did not fail when defining a Serializer without a Meta class")
+        except ImproperlyConfigured as e:
+            self.assertEqual(str(e), "%s must implement a Meta class or have the property _abstract" % "FacetSerializer")
 
 class HaystackSerializerMixinTestCase(WarningTestCaseMixin, TestCase):
 
@@ -710,3 +644,46 @@ class HaystackMultiSerializerTestCase(WarningTestCaseMixin, TestCase):
                 "description": "Zane is a nice chap!"
             }]
         )
+
+
+class TestHaystackSerializerMeta(SimpleTestCase):
+
+    def test_abstract_not_inherited(self):
+        class Base(six.with_metaclass(HaystackSerializerMeta, serializers.Serializer)):
+            _abstract = True
+
+        def create_subclass():
+            class Sub(HaystackSerializer):
+                pass
+
+        self.assertRaises(ImproperlyConfigured, create_subclass)
+
+
+class TestMeta(SimpleTestCase):
+
+    def test_inheritance(self):
+        """
+        Tests that Meta fields are correctly overriden by subclasses.
+        """
+        class Serializer(HaystackSerializer):
+            class Meta:
+                fields = ('overriden_fields',)
+
+        self.assertEqual(Serializer.Meta.fields, ('overriden_fields',))
+
+    def test_default_attrs(self):
+        class Serializer(HaystackSerializer):
+            class Meta:
+                fields = ('overriden_fields',)
+
+        self.assertEqual(Serializer.Meta.exclude, tuple())
+
+    def test_raises_if_fields_and_exclude_defined(self):
+        def create_subclass():
+            class Serializer(HaystackSerializer):
+                class Meta:
+                    fields = ('include_field',)
+                    exclude = ('exclude_field',)
+            return Serializer
+
+        self.assertRaises(ImproperlyConfigured, create_subclass)


### PR DESCRIPTION
I would like to build in some greater support for preprocess filtering without using the `FacetFilter`, but the query building logic and the filters were quite tightly coupled. So I've refactored some of the codebase to make it easier to change things.

Changes:
* Moved the parameter-building logic for filters (with the exception of GeoFilter since the tests were being skipped) to `QueryBuilder`. This should make it easier to subclass and build more specific backend support without creating lots of filters.
* I've added some meta classes in the serializers so that you don't need to use `getattr` for the meta attributes.
* Now if meta classes are incorrectly configured (or a serializer does not define Meta without being abstract) it will throw an exception when the class itself is defined, rather than the method called. I think this is a good change but has a problem with backwards compatibility? 
* Raised test settings log levels (#40)

If you're not happy with any of these changes, let me know :) I've added test coverage for the meta classes, but haven't bothered with docs unless you're happy with this.