### PR TITLE
Moved filter query building logic and added meta classes to handle integrity of serializers

### DIFF
--- a/drf_haystack/constants.py
+++ b/drf_haystack/constants.py
@@ -1,0 +1,3 @@
+from django.conf import settings
+
+DRF_HAYSTACK_NEGATION_KEYWORD = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -31,7 +31,7 @@ class HaystackFilter(BaseFilterBackend):
         return request.GET.copy()
 
     @classmethod
-    def build_filter(cls, view, filters=None):
+    def build_filters(cls, view, filters=None):
         """
         Creates a single SQ filter from querystring parameters that
         correspond to the SearchIndex fields that have been "registered"

--- a/drf_haystack/filters.py
+++ b/drf_haystack/filters.py
@@ -6,7 +6,6 @@ import operator
 import warnings
 from itertools import chain
 
-from dateutil import parser
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -17,7 +16,7 @@ from haystack.query import SearchQuerySet
 
 from rest_framework.filters import BaseFilterBackend
 
-from .utils import merge_dict
+from .query import QueryBuilder
 
 
 class HaystackFilter(BaseFilterBackend):
@@ -25,11 +24,14 @@ class HaystackFilter(BaseFilterBackend):
     A filter backend that compiles a haystack compatible filtering query.
     """
 
+    query_builder = QueryBuilder()
+
     @staticmethod
     def get_request_filters(request):
         return request.GET.copy()
 
-    def build_filters(self, view, filters=None):
+    @classmethod
+    def build_filter(cls, view, filters=None):
         """
         Creates a single SQ filter from querystring parameters that
         correspond to the SearchIndex fields that have been "registered"
@@ -41,61 +43,7 @@ class HaystackFilter(BaseFilterBackend):
         Any querystring parameters that are not registered in
         `view.fields` will be ignored.
         """
-
-        applicable_filters = []
-        applicable_exclusions = []
-
-        if filters is None:
-            filters = {}  # pragma: no cover
-
-        for param, value in filters.items():
-            # Skip if the parameter is not listed in the serializer's `fields`
-            # or if it's in the `exclude` list.
-            excluding_term = False
-            param_parts = param.split("__")
-            base_param = param_parts[0]  # only test against field without lookup
-            negation_keyword = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")
-            if len(param_parts) > 1 and param_parts[1] == negation_keyword:
-                excluding_term = True
-                param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
-
-            if view.serializer_class:
-                try:
-                    if hasattr(view.serializer_class.Meta, "field_aliases"):
-                        old_base = base_param
-                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
-                        param = param.replace(old_base, base_param)  # need to replace the alias
-
-                    fields = getattr(view.serializer_class.Meta, "fields", [])
-                    exclude = getattr(view.serializer_class.Meta, "exclude", [])
-                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
-
-                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
-                        continue
-
-                except AttributeError:
-                    raise ImproperlyConfigured("%s must implement a Meta class." %
-                                               view.serializer_class.__class__.__name__)
-
-            tokens = [token.strip() for token in value.split(view.lookup_sep)]
-            field_queries = []
-
-            for token in tokens:
-                if token:
-                    field_queries.append(view.query_object((param, token)))
-
-            term = six.moves.reduce(operator.or_, filter(lambda x: x, field_queries))
-            if excluding_term:
-                applicable_exclusions.append(term)
-            else:
-                applicable_filters.append(term)
-
-        applicable_filters = six.moves.reduce(
-            operator.and_, filter(lambda x: x, applicable_filters)) if applicable_filters else []
-        applicable_exclusions = six.moves.reduce(
-            operator.and_, filter(lambda x: x, applicable_exclusions)) if applicable_exclusions else []
-
-        return applicable_filters, applicable_exclusions
+        return cls.query_builder.build_query(view, **(filters if filters else {}))
 
     @staticmethod
     def apply_filters(queryset, applicable_filters=None, applicable_exclusions=None):
@@ -309,93 +257,12 @@ class HaystackFacetFilter(HaystackFilter):
 
     # TODO: Support multiple indexes/serializers
 
-    @staticmethod
-    def parse(lookup_sep, options):
-        """
-        Parse the field options query string and return it as a dictionary.
-        """
-        defaults = {}
-        if isinstance(options, six.text_type):
-
-            tokens = [token.strip() for token in options.split(lookup_sep)]
-
-            for token in tokens:
-                if not len(token.split(":")) == 2:
-                    warnings.warn("The %s token is not properly formatted. Tokens need to be "
-                                  "formatted as 'token:value' pairs." % token)
-                    continue
-
-                param, value = token.split(":")
-
-                if any([k == param for k in ("start_date", "end_date", "gap_amount")]):
-
-                    if param in ("start_date", "end_date"):
-                        value = parser.parse(value)
-
-                    if param == "gap_amount":
-                        value = int(value)
-
-                defaults[param] = value
-
-        return defaults
-
     def build_facet_filter(self, view, filters=None):
         """
         Creates a dict of dictionaries suitable for passing to the
         SearchQuerySet ``facet``, ``date_facet`` or ``query_facet`` method.
         """
-
-        field_facets = {}
-        date_facets = {}
-        query_facets = {}
-        facet_serializer_cls = view.get_facet_serializer_class()
-
-        if filters is None:
-            filters = {}  # pragma: no cover
-
-        if view.lookup_sep == ":":
-            raise AttributeError("The %(cls)s.lookup_sep attribute conflicts with the HaystackFacetFilter "
-                                 "query parameter parser. Please choose another `lookup_sep` attribute "
-                                 "for %(cls)s." % {"cls": view.__class__.__name__})
-
-        try:
-            fields = getattr(facet_serializer_cls.Meta, "fields", [])
-            exclude = getattr(facet_serializer_cls.Meta, "exclude", [])
-            field_options = getattr(facet_serializer_cls.Meta, "field_options", {})
-
-            for field, options in filters.items():
-
-                if field not in fields or field in exclude:
-                    continue
-
-                field_options = merge_dict(field_options, {field: self.parse(view.lookup_sep, options)})
-
-            valid_gap = ("year", "month", "day", "hour", "minute", "second")
-            for field, options in field_options.items():
-                if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
-
-                    if not all(("start_date", "end_date", "gap_by" in options)):
-                        raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
-                                         "and 'gap_by' to be set.")
-
-                    if not options["gap_by"] in valid_gap:
-                        raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
-
-                    options.setdefault("gap_amount", 1)
-                    date_facets[field] = field_options[field]
-
-                else:
-                    field_facets[field] = field_options[field]
-
-        except AttributeError:
-            raise ImproperlyConfigured("%s must implement a Meta class." %
-                                       facet_serializer_cls.__class__.__name__)
-
-        return {
-            "date_facets": date_facets,
-            "field_facets": field_facets,
-            "query_facets": query_facets
-        }
+        return self.query_builder.build_facet_query(view, **(filters if filters else {}))
 
     @staticmethod
     def apply_facets(queryset, filters):

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -136,8 +136,8 @@ class QueryBuilder:
             "query_facets": query_facets
         }
 
-    def build_geo_query(self, view, filters):
-        pass
+    def build_geo_query(self, view, **kwargs):
+        raise NotImplemented("GEO Queries are currently handled by subclassing BaseHaystackGEOSpatialFilter")
 
     def tokenize(self, stream, seperator):
         """

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -1,0 +1,181 @@
+import operator
+import warnings
+from itertools import chain
+
+import six
+from dateutil import parser
+from django.core.exceptions import ImproperlyConfigured
+from drf_haystack.utils import merge_dict
+from . import constants
+
+
+class QueryBuilder:
+
+    """
+    Builds query parameters for haystack filters.
+    """
+
+    def build_query(self, view, **kwargs):
+        """
+        Creates a single SQ filter from querystring parameters that correspond to the SearchIndex fields
+        that have been "registered" in `view.fields`.
+
+        Default behavior is to `OR` terms for the same parameters, and `AND` between parameters. Any
+        querystring parameters that are not registered in `view.fields` will be ignored.
+
+        :param view:
+        :param dict[str, list[str]] kwargs: is an expanded QueryDict or a mapping of keys to a list of
+        parameters.
+        """
+
+        applicable_filters = []
+        applicable_exclusions = []
+
+        for param, value in kwargs.items():
+            # Skip if the parameter is not listed in the serializer's `fields`
+            # or if it's in the `exclude` list.
+            excluding_term = False
+            param_parts = param.split("__")
+            base_param = param_parts[0]  # only test against field without lookup
+            negation_keyword = constants.DRF_HAYSTACK_NEGATION_KEYWORD
+            if len(param_parts) > 1 and param_parts[1] == negation_keyword:
+                excluding_term = True
+                param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
+
+            if view.serializer_class:
+                try:
+                    if hasattr(view.serializer_class.Meta, "field_aliases"):
+                        old_base = base_param
+                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
+                        param = param.replace(old_base, base_param)  # need to replace the alias
+
+                    fields = getattr(view.serializer_class.Meta, "fields", [])
+                    exclude = getattr(view.serializer_class.Meta, "exclude", [])
+                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
+
+                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
+                        continue
+
+                except AttributeError:
+                    raise ImproperlyConfigured("%s must implement a Meta class." %
+                                               view.serializer_class.__class__.__name__)
+
+            field_queries = []
+            for token in self.tokenize(value, view.lookup_sep):
+                field_queries.append(view.query_object((param, token)))
+
+            term = six.moves.reduce(operator.or_, filter(lambda x: x, field_queries))
+            if excluding_term:
+                applicable_exclusions.append(term)
+            else:
+                applicable_filters.append(term)
+
+        applicable_filters = \
+            six.moves.reduce(operator.and_, filter(lambda x: x, applicable_filters)) if applicable_filters else []
+
+        applicable_exclusions = \
+            six.moves.reduce(operator.and_, filter(lambda x: x, applicable_exclusions)) if applicable_exclusions else []
+
+        return applicable_filters, applicable_exclusions
+
+    def build_facet_query(self, view, **kwargs):
+        """
+        Creates a dict of dictionaries suitable for passing to the SearchQuerySet ``facet``, ``date_facet``
+        or ``query_facet`` method. All key word arguments should be wrapped in a list.
+
+        :param view:
+        :param dict[str, list[str]] kwargs: is an expanded QueryDict or a mapping of keys to a list of
+        parameters.
+        """
+        field_facets = {}
+        date_facets = {}
+        query_facets = {}
+        facet_serializer_cls = view.get_facet_serializer_class()
+
+        if view.lookup_sep == ":":
+            raise AttributeError("The %(cls)s.lookup_sep attribute conflicts with the HaystackFacetFilter "
+                                 "query parameter parser. Please choose another `lookup_sep` attribute "
+                                 "for %(cls)s." % {"cls": view.__class__.__name__})
+
+        try:
+            fields = getattr(facet_serializer_cls.Meta, "fields", [])
+            exclude = getattr(facet_serializer_cls.Meta, "exclude", [])
+            field_options = getattr(facet_serializer_cls.Meta, "field_options", {})
+
+            for field, options in kwargs.items():
+
+                if field not in fields or field in exclude:
+                    continue
+
+                field_options = merge_dict(field_options, {field: self.parse_field_options(view.lookup_sep, *options)})
+
+            valid_gap = ("year", "month", "day", "hour", "minute", "second")
+            for field, options in field_options.items():
+                if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
+
+                    if not all(("start_date", "end_date", "gap_by" in options)):
+                        raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
+                                         "and 'gap_by' to be set.")
+
+                    if not options["gap_by"] in valid_gap:
+                        raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
+
+                    options.setdefault("gap_amount", 1)
+                    date_facets[field] = field_options[field]
+
+                else:
+                    field_facets[field] = field_options[field]
+
+        except AttributeError:
+            raise ImproperlyConfigured("%s must implement a Meta class." %
+                                       facet_serializer_cls.__class__.__name__)
+
+        return {
+            "date_facets": date_facets,
+            "field_facets": field_facets,
+            "query_facets": query_facets
+        }
+
+    def build_geo_query(self, view, filters):
+        pass
+
+    def tokenize(self, stream, seperator):
+        """
+        Tokenizes a value into
+        :param stream:
+        :param seperator:
+        :return:
+        """
+        for value in stream:
+            for token in value.split(seperator):
+                if token:
+                    yield token.strip()
+
+    def parse_field_options(self, lookup_sep, *options):
+        """
+        Parse the field options query string and return it as a dictionary.
+        """
+        defaults = {}
+        for option in options:
+            if isinstance(option, six.text_type):
+                tokens = [token.strip() for token in option.split(lookup_sep)]
+
+                for token in tokens:
+                    if not len(token.split(":")) == 2:
+                        warnings.warn("The %s token is not properly formatted. Tokens need to be "
+                                      "formatted as 'token:value' pairs." % token)
+                        continue
+
+                    param, value = token.split(":")
+
+                    if any([k == param for k in ("start_date", "end_date", "gap_amount")]):
+
+                        if param in ("start_date", "end_date"):
+                            value = parser.parse(value)
+
+                        if param == "gap_amount":
+                            value = int(value)
+
+                    defaults[param] = value
+
+        return defaults

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -43,22 +43,17 @@ class QueryBuilder:
                 param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
 
             if view.serializer_class:
-                try:
-                    if hasattr(view.serializer_class.Meta, "field_aliases"):
-                        old_base = base_param
-                        base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
-                        param = param.replace(old_base, base_param)  # need to replace the alias
+                if view.serializer_class.Meta.field_aliases:
+                    old_base = base_param
+                    base_param = view.serializer_class.Meta.field_aliases.get(base_param, base_param)
+                    param = param.replace(old_base, base_param)  # need to replace the alias
 
-                    fields = getattr(view.serializer_class.Meta, "fields", [])
-                    exclude = getattr(view.serializer_class.Meta, "exclude", [])
-                    search_fields = getattr(view.serializer_class.Meta, "search_fields", [])
+                fields = view.serializer_class.Meta.fields
+                exclude = view.serializer_class.Meta.exclude
+                search_fields = view.serializer_class.Meta.search_fields
 
-                    if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
-                        continue
-
-                except AttributeError:
-                    raise ImproperlyConfigured("%s must implement a Meta class." %
-                                               view.serializer_class.__class__.__name__)
+                if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
+                    continue
 
             field_queries = []
             for token in self.tokenize(value, view.lookup_sep):
@@ -97,38 +92,33 @@ class QueryBuilder:
                                  "query parameter parser. Please choose another `lookup_sep` attribute "
                                  "for %(cls)s." % {"cls": view.__class__.__name__})
 
-        try:
-            fields = getattr(facet_serializer_cls.Meta, "fields", [])
-            exclude = getattr(facet_serializer_cls.Meta, "exclude", [])
-            field_options = getattr(facet_serializer_cls.Meta, "field_options", {})
+        fields = facet_serializer_cls.Meta.fields
+        exclude = facet_serializer_cls.Meta.exclude
+        field_options = facet_serializer_cls.Meta.field_options
 
-            for field, options in kwargs.items():
+        for field, options in kwargs.items():
 
-                if field not in fields or field in exclude:
-                    continue
+            if field not in fields or field in exclude:
+                continue
 
-                field_options = merge_dict(field_options, {field: self.parse_field_options(view.lookup_sep, *options)})
+            field_options = merge_dict(field_options, {field: self.parse_field_options(view.lookup_sep, *options)})
 
-            valid_gap = ("year", "month", "day", "hour", "minute", "second")
-            for field, options in field_options.items():
-                if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
+        valid_gap = ("year", "month", "day", "hour", "minute", "second")
+        for field, options in field_options.items():
+            if any([k in options for k in ("start_date", "end_date", "gap_by", "gap_amount")]):
 
-                    if not all(("start_date", "end_date", "gap_by" in options)):
-                        raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
-                                         "and 'gap_by' to be set.")
+                if not all(("start_date", "end_date", "gap_by" in options)):
+                    raise ValueError("Date faceting requires at least 'start_date', 'end_date' "
+                                     "and 'gap_by' to be set.")
 
-                    if not options["gap_by"] in valid_gap:
-                        raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
+                if not options["gap_by"] in valid_gap:
+                    raise ValueError("The 'gap_by' parameter must be one of %s." % ", ".join(valid_gap))
 
-                    options.setdefault("gap_amount", 1)
-                    date_facets[field] = field_options[field]
+                options.setdefault("gap_amount", 1)
+                date_facets[field] = field_options[field]
 
-                else:
-                    field_facets[field] = field_options[field]
-
-        except AttributeError:
-            raise ImproperlyConfigured("%s must implement a Meta class." %
-                                       facet_serializer_cls.__class__.__name__)
+            else:
+                field_facets[field] = field_options[field]
 
         return {
             "date_facets": date_facets,

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -48,7 +48,7 @@ class Meta(type):
     index_aliases = {}
 
     def __new__(mcs, name, bases, attrs):
-        cls = super().__new__(mcs, name, bases, attrs)
+        cls = super(Meta, mcs).__new__(mcs, str(name), bases, attrs)
 
         if cls.fields and cls.exclude:
             raise ImproperlyConfigured("%s cannot define fields and exclude" % name)
@@ -71,7 +71,7 @@ class HaystackSerializerMeta(SerializerMetaclass):
     def __new__(mcs, name, bases, attrs):
         attrs.setdefault('_abstract', False)
 
-        cls = super(HaystackSerializerMeta, mcs).__new__(mcs, name, bases, attrs)
+        cls = super(HaystackSerializerMeta, mcs).__new__(mcs, str(name), bases, attrs)
 
         if getattr(cls, "Meta", None):
             cls.Meta = Meta("Meta", (Meta,), dict(cls.Meta.__dict__))

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -96,7 +96,7 @@ LOGGING = {
     'loggers': {
         'default': {
             'handlers': ['file_handler'],
-            'level': 'DEBUG',
+            'level': 'INFO',
             'propagate': True,
         },
         'elasticsearch': {

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -155,15 +155,6 @@ class HaystackFilterTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 3)
 
-    def test_filter_raise_on_serializer_without_meta_class(self):
-        # Make sure we're getting an ImproperlyConfigured when trying to filter on a viewset
-        # with a serializer without `Meta` class.
-        request = factory.get(path="/", data={"lastname": "Hood"}, content_type="application/json")
-        self.assertRaises(
-            ImproperlyConfigured,
-            self.view3.as_view(actions={"get": "list"}), request
-        )
-
     def test_filter_unicode_characters(self):
         request = factory.get(path="/", data={"firstname": "åsmund", "lastname": "sørensen"},
                               content_type="application/json")


### PR DESCRIPTION
Replacement for #41

I think the filters and query related logic could be even more refactored. Move the remaining validation logic somewhere else so that they’re easier to test. Beyond the Meta though I couldn’t come up with a consistent way to do it. Food for thought.