### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ Build status
 [![Build Status](https://travis-ci.org/inonit/drf-haystack.svg?branch=master)](https://travis-ci.org/inonit/drf-haystack)
 [![Coverage Status](https://coveralls.io/repos/github/inonit/drf-haystack/badge.svg?branch=master)](https://coveralls.io/github/inonit/drf-haystack?branch=master)
 [![PyPI version](https://badge.fury.io/py/drf-haystack.svg)](https://badge.fury.io/py/drf-haystack)
-[![Documentation Status](http://readthedocs.org/projects/drf-haystack/badge/?version=latest)](http://drf-haystack.readthedocs.org/en/latest/?badge=latest)
+[![Documentation Status](http://readthedocs.org/projects/drf-haystack/badge/?version=latest)](https://drf-haystack.readthedocs.io/en/latest/?badge=latest)
 
 
 About
 -----
 
 Small library which tries to simplify integration of Haystack with Django REST Framework.
-Fresh [documentation available](http://drf-haystack.readthedocs.org/en/latest/>) on Read the docs!
+Fresh [documentation available](https://drf-haystack.readthedocs.io/en/latest/>) on Read the docs!
 
 Supported versions
 ------------------

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -11,7 +11,7 @@ Query Field Lookups
 ===================
 
 You can also use field lookups in your field queries. See the
-Haystack `field lookups <https://django-haystack.readthedocs.org/en/latest/searchqueryset_api.html?highlight=lookups#id1>`_
+Haystack `field lookups <https://django-haystack.readthedocs.io/en/latest/searchqueryset_api.html?highlight=lookups#id1>`_
 documentation for info on what lookups are available.  A query using a lookup might look like the
 following:
 
@@ -166,7 +166,7 @@ from the location with latitude 59.744076 and longitude 10.152045.
 Highlighting
 ============
 
-Haystack supports two kinds of `Highlighting <https://django-haystack.readthedocs.org/en/latest/highlighting.html>`_,
+Haystack supports two kinds of `Highlighting <https://django-haystack.readthedocs.io/en/latest/highlighting.html>`_,
 and we support them both.
 
 #. SearchQuerySet highlighting. This kind of highlighting requires a search backend which has support for
@@ -370,7 +370,7 @@ Term Boost
     **BIG FAT WARNING**
 
     As far as I can see, the term boost functionality is implemented by the specs in the
-    `Haystack documentation <https://django-haystack.readthedocs.org/en/v2.4.0/boost.html#term-boost>`_,
+    `Haystack documentation <https://django-haystack.readthedocs.io/en/v2.4.0/boost.html#term-boost>`_,
     however it does not really work as it should!
 
     When applying term boost, results are discarded from the search result, and not re-ordered by
@@ -433,7 +433,7 @@ functionality is implemented by setting up a special ``^search/facets/$`` route 
     options suitable for the backend you're using.
 
 
-First, read the `Haystack faceting docs <http://django-haystack.readthedocs.org/en/latest/faceting.html>`_ and set up
+First, read the `Haystack faceting docs <https://django-haystack.readthedocs.io/en/latest/faceting.html>`_ and set up
 your search index for faceting.
 
 Serializing faceted counts

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -287,8 +287,8 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'http://docs.python.org/': None,
-    'django': ('http://django.readthedocs.org/en/latest/', None),
-    'haystack': ('http://django-haystack.readthedocs.org/en/latest/', None)
+    'django': ('https://django.readthedocs.io/en/latest/', None),
+    'haystack': ('https://django-haystack.readthedocs.io/en/latest/', None)
 }
 
 # Configurations for extlinks

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -50,7 +50,7 @@ You will also need to install python bindings for the search engine you'll use.
 Elasticsearch
 .............
 
-See haystack `Elasticsearch <https://django-haystack.readthedocs.org/en/v2.4.1/installing_search_engines.html#elasticsearch>`_
+See haystack `Elasticsearch <https://django-haystack.readthedocs.io/en/v2.4.1/installing_search_engines.html#elasticsearch>`_
 docs for details
 
 .. warning::
@@ -65,7 +65,7 @@ docs for details
 Solr
 ....
 
-See haystack `Solr <https://django-haystack.readthedocs.org/en/v2.4.1/installing_search_engines.html#solr>`_
+See haystack `Solr <https://django-haystack.readthedocs.io/en/v2.4.1/installing_search_engines.html#solr>`_
 docs for details.
 
 .. code-block:: none
@@ -75,7 +75,7 @@ docs for details.
 Whoosh
 ......
 
-See haystack `Whoosh <https://django-haystack.readthedocs.org/en/v2.4.1/installing_search_engines.html#whoosh>`_
+See haystack `Whoosh <https://django-haystack.readthedocs.io/en/v2.4.1/installing_search_engines.html#whoosh>`_
 docs for details.
 
 .. code-block:: none
@@ -85,7 +85,7 @@ docs for details.
 Xapian
 ......
 
-See haystack `Xapian <https://django-haystack.readthedocs.org/en/v2.4.1/installing_search_engines.html#xapian>`_
+See haystack `Xapian <https://django-haystack.readthedocs.io/en/v2.4.1/installing_search_engines.html#xapian>`_
 docs for details.
 
 
@@ -174,7 +174,7 @@ v1.5.0
 *Release date: 2015-06-29*
 
     - Added support for field lookups in queries, such as ``field__contains=foobar``.
-      Check out `Haystack docs <http://django-haystack.readthedocs.org/en/latest/searchqueryset_api.html?highlight=field%20lookup#field-lookups>`_
+      Check out `Haystack docs <https://django-haystack.readthedocs.io/en/latest/searchqueryset_api.html?highlight=field%20lookup#field-lookups>`_
       for details.
     - Added default ``permission_classes`` on ``HaystackGenericAPIView`` in order to avoid crash when
       using global permission classes on REST Framework. See :ref:`permission-classes-label` for details.


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.