### PR TITLE
Added query param text & made MLT/Faceting mixins more usable

### DIFF
--- a/docs/07_faceting.rst
+++ b/docs/07_faceting.rst
@@ -241,6 +241,9 @@ Any view that inherits the :class:`drf_haystack.mixins.FacetMixin` will have a s
 In order to set up a view which can respond to regular queries under ie ``^search/$`` and faceted queries under
 ``^search/facets/$``, we could do something like this.
 
+We can also change the query param text from ``selected_facets`` to our own choice like ``params`` or ``p``. For this 
+to make happen please provide ``facet_query_params_text`` attribute as shown in the example. 
+
 .. code-block:: python
 
     class SearchPersonViewSet(FacetMixin, HaystackViewSet):
@@ -257,6 +260,7 @@ In order to set up a view which can respond to regular queries under ie ``^searc
         facet_serializer_class = PersonFacetSerializer  # See example above!
         facet_filter_backends = [HaystackFacetFilter]   # This is the default facet filter, and
                                                         # can be left out.
+        facet_query_params_text = 'params' #Default is 'selected_facets'
 
 
 Narrowing

--- a/docs/10_tips_n_tricks.rst
+++ b/docs/10_tips_n_tricks.rst
@@ -75,3 +75,27 @@ but can do with a regular view. In such scenario you could do something like thi
         url(r'^search/', SearchView.as_view()),
        ...
     )
+
+You can also use `FacetMixin` or `MoreLikeThisMixin` in your regular views as well.
+
+.. code-block:: python
+
+    #
+    # views.py
+    #
+
+    from rest_framework.mixins import ListModelMixin
+    from drf_haystack.mixins import FacetMixin
+    from drf_haystack.generics import HaystackGenericAPIView
+
+
+    class SearchView(ListModelMixin, FacetMixin, HaystackGenericAPIView):
+        index_models = [Project]
+        serializer_class = ProjectListSerializer
+        facet_serializer_class = ProjectListFacetSerializer
+
+        pagination_class = BasicPagination
+        permission_classes = (AllowAny,)
+
+        def get(self, request, *args, **kwargs):
+            return self.facets(request, *args, **kwargs)

--- a/drf_haystack/mixins.py
+++ b/drf_haystack/mixins.py
@@ -41,17 +41,17 @@ class FacetMixin(object):
     facet_filter_backends = [HaystackFacetFilter]
     facet_serializer_class = None
     facet_objects_serializer_class = None
+    facet_query_params_text = 'selected_facets'
 
     @list_route(methods=["get"], url_path="facets")
     def facets(self, request):
         """
         Sets up a list route for ``faceted`` results.
-
         This will add ie ^search/facets/$ to your existing ^search pattern.
         """
         queryset = self.filter_facet_queryset(self.get_queryset())
 
-        for facet in request.query_params.getlist("selected_facets"):
+        for facet in request.query_params.getlist(self.facet_query_params_text):
 
             if ":" not in facet:
                 continue
@@ -86,7 +86,8 @@ class FacetMixin(object):
         facet_serializer_class = self.get_facet_serializer_class()
         kwargs["context"] = self.get_serializer_context()
         kwargs["context"].update({
-            "objects": kwargs.pop("objects")
+            "objects": kwargs.pop("objects"),
+            "facet_query_params_text": self.facet_query_params_text,
         })
         return facet_serializer_class(*args, **kwargs)
 
@@ -119,4 +120,3 @@ class FacetMixin(object):
         ``self.facet_objects_serializer_class`` is set.
         """
         return self.facet_objects_serializer_class or super(FacetMixin, self).get_serializer_class()
-

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -348,9 +348,9 @@ class FacetFieldSerializer(serializers.Serializer):
         if page_query_param in query_params:
             del query_params[page_query_param]
 
-        selected_facets = set(query_params.pop("selected_facets", []))
+        selected_facets = set(query_params.pop(self.root.facet_query_params_text, []))
         selected_facets.add("%(field)s_exact:%(text)s" % {"field": self.parent_field, "text": text})
-        query_params.setlist("selected_facets", sorted(selected_facets))
+        query_params.setlist(self.root.facet_query_params_text, sorted(selected_facets))
 
         path = "%(path)s?%(query)s" % {"path": request.path_info, "query": query_params.urlencode()}
         url = request.build_absolute_uri(path)
@@ -414,6 +414,10 @@ class HaystackFacetSerializer(six.with_metaclass(HaystackSerializerMeta, seriali
 
         serializer = view.get_serializer(queryset, many=True)
         return serializer.data
+
+    @property
+    def facet_query_params_text(self):
+        return self.context["facet_query_params_text"]
 
 
 class HaystackSerializerMixin(object):


### PR DESCRIPTION
Added these two features

- URL param can be defined in the view itself. We need to define attribute `facet_query_params_text` on intended view to  replace ``selected_facets`` query text in urls.

- Made MoreLikeThisMixin and FacetMixin more usable by removing dependency of viewset. `MoreLikeThisBaseMixin` and `FacetBaseMixin` can be used in regular views.