### PR TITLE
Removed field override warning

### DIFF
--- a/docs/09_multiple_indexes.rst
+++ b/docs/09_multiple_indexes.rst
@@ -138,3 +138,31 @@ for different indexes as show below:
 The ``serializers`` attribute is the important thing here, It's a dictionary with ``SearchIndex`` classes as
 keys and ``Serializer`` classes as values.  Each result in the list of results from a search that contained
 items from multiple indexes would be serialized according to the appropriate serializer.
+
+.. warning::
+
+    If a field name is shared across serializers, and one serializer overrides the field mapping, the overridden
+    mapping will be used for *all* serializers. See the example below for more details.
+
+.. code-block:: python
+
+    from rest_framework import serializers
+
+    class PersonSearchSerializer(HaystackSerializer):
+        # NOTE: This override will be used for both Person and Place objects.
+        name = serializers.SerializerMethodField()
+
+        class Meta:
+            fields = ['name']
+
+    class PlaceSearchSerializer(HaystackSerializer):
+        class Meta:
+            fields = ['name']
+
+    class AggregateSearchSerializer(HaystackSerializer):
+        class Meta:
+            serializers = {
+                PersonIndex: PersonSearchSerializer,
+                PlaceIndex: PlaceSearchSerializer,
+                ThingIndex: ThingSearchSerializer
+            }

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -209,9 +209,6 @@ class HaystackSerializer(six.with_metaclass(HaystackSerializerMeta, serializers.
         # in case of naming collision!.
         if declared_fields:
             for field_name in declared_fields:
-                if field_name in field_mapping:
-                    warnings.warn("Field '{field}' already exists in the field list. This *will* "
-                                  "overwrite existing field '{field}'".format(field=field_name))
                 field_mapping[field_name] = declared_fields[field_name]
         return field_mapping
 


### PR DESCRIPTION
These warnings can be somewhat noisy when the override behavior is expected. The warning has been removed, and a note added to the documentation.

Fixes #77