### PR TITLE
drf 3.5, fix TypeError

### DIFF
--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -346,7 +346,7 @@ class FacetFieldSerializer(serializers.Serializer):
 
         path = "%(path)s?%(query)s" % {"path": request.path_info, "query": query_params.urlencode()}
         url = request.build_absolute_uri(path)
-        return serializers.Hyperlink(url, name="narrow-url")
+        return serializers.Hyperlink(url, "narrow-url")
 
     def to_representation(self, field, instance):
         """


### PR DESCRIPTION
With django-rest-framework 3.5 Hyperlink 'name' as made 'lazy',
changing the name argument in the process.
If we call it without a keyword, it should work in both old and new drf
verions.
