### PR TITLE
(fix) queryset attr evaluates to False when empty

### DIFF
--- a/drf_haystack/generics.py
+++ b/drf_haystack/generics.py
@@ -45,7 +45,7 @@ class HaystackGenericAPIView(GenericAPIView):
 
         @:param index_models: override `self.index_models`
         """
-        if hasattr(self, "queryset") and isinstance(self.queryset, self.object_class):
+        if self.queryset is None and isinstance(self.queryset, self.object_class):
             queryset = self.queryset.all()
         else:
             queryset = self.object_class()._clone()

--- a/drf_haystack/generics.py
+++ b/drf_haystack/generics.py
@@ -45,7 +45,7 @@ class HaystackGenericAPIView(GenericAPIView):
 
         @:param index_models: override `self.index_models`
         """
-        if self.queryset and isinstance(self.queryset, self.object_class):
+        if hasattr(self, "queryset") and isinstance(self.queryset, self.object_class):
             queryset = self.queryset.all()
         else:
             queryset = self.object_class()._clone()


### PR DESCRIPTION
Fix for bug in get_queryset() where the queryset attribute is set, but evaluates to empty list, causing ELSE to be triggered