### PR TITLE
Corrected what seemed like the omission of a "not" in HaystackGenericAPIView

### DIFF
--- a/drf_haystack/generics.py
+++ b/drf_haystack/generics.py
@@ -45,7 +45,7 @@ class HaystackGenericAPIView(GenericAPIView):
 
         @:param index_models: override `self.index_models`
         """
-        if self.queryset is None and isinstance(self.queryset, self.object_class):
+        if self.queryset is not None and isinstance(self.queryset, self.object_class):
             queryset = self.queryset.all()
         else:
             queryset = self.object_class()._clone()


### PR DESCRIPTION
This was causing the `queryset` attribute to be ignored. (#90)