### PR TITLE
Add DRF_HAYSTACK_SPATIAL_QUERY_PARAM to constants

### DIFF
--- a/docs/03_geospatial.rst
+++ b/docs/03_geospatial.rst
@@ -27,6 +27,7 @@ The geospatial filter is somewhat special, and for the time being, relies on a f
 #. The query **must** contain a ``unit`` parameter where the unit is a valid ``UNIT`` in the ``django.contrib.gis.measure.Distance`` class.
 #. The query **must** contain a ``from`` parameter which is a comma separated longitude and latitude value.
 
+You may also change the query param ``from`` by defining ``DRF_HAYSTACK_SPATIAL_QUERY_PARAM`` on your settings.
 
 **Example Geospatial view**
 

--- a/drf_haystack/constants.py
+++ b/drf_haystack/constants.py
@@ -2,3 +2,4 @@ from django.conf import settings
 
 DRF_HAYSTACK_NEGATION_KEYWORD = getattr(settings, "DRF_HAYSTACK_NEGATION_KEYWORD", "not")
 GEO_SRID = getattr(settings, "GEO_SRID", 4326)
+DRF_HAYSTACK_SPATIAL_QUERY_PARAM = getattr(settings, "DRF_HAYSTACK_SPATIAL_QUERY_PARAM", "from")

--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -276,11 +276,11 @@ class SpatialQueryBuilder(BaseQueryBuilder):
 
         applicable_filters = None
 
-        filters = dict((k, filters[k]) for k in chain(self.D.UNITS.keys(), ["from"]) if k in filters)
+        filters = dict((k, filters[k]) for k in chain(self.D.UNITS.keys(), [constants.DRF_HAYSTACK_SPATIAL_QUERY_PARAM]) if k in filters)
         distance = dict((k, v) for k, v in filters.items() if k in self.D.UNITS.keys())
 
         try:
-            latitude, longitude = map(float, self.tokenize(filters["from"], self.view.lookup_sep))
+            latitude, longitude = map(float, self.tokenize(filters[constants.DRF_HAYSTACK_SPATIAL_QUERY_PARAM], self.view.lookup_sep))
             point = self.Point(longitude, latitude, srid=constants.GEO_SRID)
         except ValueError:
             raise ValueError("Cannot convert `from=latitude,longitude` query parameter to "


### PR DESCRIPTION
It allow to change the default argument 'from' to anoter keywork,
since it may cause some trouble when using Serializers to validate
the query parameters, as this is a python reserved keyword.