### PR TITLE
safe attribute access

### DIFF
--- a/drf_haystack/query.py
+++ b/drf_haystack/query.py
@@ -113,14 +113,14 @@ class FilterQueryBuilder(BaseQueryBuilder):
                 param = param.replace("__%s" % negation_keyword, "")  # haystack wouldn't understand our negation
 
             if self.view.serializer_class:
-                if self.view.serializer_class.Meta.field_aliases:
+                if hasattr(self.view.serializer_class.Meta, 'field_aliases'):
                     old_base = base_param
                     base_param = self.view.serializer_class.Meta.field_aliases.get(base_param, base_param)
                     param = param.replace(old_base, base_param)  # need to replace the alias
 
-                fields = self.view.serializer_class.Meta.fields
-                exclude = self.view.serializer_class.Meta.exclude
-                search_fields = self.view.serializer_class.Meta.search_fields
+                fields = getattr(self.view.serializer_class.Meta, 'fields', [])
+                exclude = getattr(self.view.serializer_class.Meta, 'exclude', [])
+                search_fields = getattr(self.view.serializer_class.Meta, 'search_fields', [])
 
                 if ((fields or search_fields) and base_param not in chain(fields, search_fields)) or base_param in exclude or not value:
                     continue
@@ -128,7 +128,7 @@ class FilterQueryBuilder(BaseQueryBuilder):
             field_queries = []
             for token in self.tokenize(value, self.view.lookup_sep):
                 field_queries.append(self.view.query_object((param, token)))
-            
+
             field_queries = [fq for fq in field_queries if fq]
             if len(field_queries) > 0:
                 term = six.moves.reduce(operator.or_, field_queries)


### PR DESCRIPTION
I came across the following error:

```
File "/usr/local/pythons/current/lib/python3.4/site-packages/drf_haystack/generics.py", line 98, in filter_queryset
    queryset = super(HaystackGenericAPIView, self).filter_queryset(queryset)
  File "/usr/local/pythons/current/lib/python3.4/site-packages/rest_framework/generics.py", line 152, in filter_queryset
    queryset = backend().filter_queryset(self.request, queryset, self)
  File "/usr/local/pythons/current/lib/python3.4/site-packages/drf_haystack/filters.py", line 58, in filter_queryset
    applicable_filters, applicable_exclusions = self.build_filters(view, filters=self.get_request_filters(request))
  File "/usr/local/pythons/current/lib/python3.4/site-packages/drf_haystack/filters.py", line 45, in build_filters
    return query_builder.build_query(**(filters if filters else {}))
  File "/usr/local/pythons/current/lib/python3.4/site-packages/drf_haystack/query.py", line 116, in build_query
    if self.view.serializer_class.Meta.field_aliases:
AttributeError: type object 'Meta' has no attribute 'field_aliases'
```
In this particular case I'm using

- Python 3.4
- Django 1.10.7
- DRF 3.6.3
- Haystack 2.6.1
- Happens on Ubuntu 14.04 and MacOS Sierra

I don't know what differences in environment exist or why the tests run on travis-ci don't encounter this, but I thought it would be good just to change to an attribute access method that would be safe regardless. 

So instead of
```python
if self.view.serializer_class.Meta.field_aliases:
```
this PR uses
```python
if hasattr(self.view.serializer_class.Meta, 'field_aliases'):
```