### PR TITLE
Clarify serializer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ from drf_haystack.viewsets import HaystackViewSet
 from myapp.search_indexes import PersonIndex  # BYOI™ (Bring Your Own Index)
 
 # Serializer
-class PersonSerializer(HaystackSerializer):
+class PersonSearchSerializer(HaystackSerializer):
     class Meta:
         index_classes = [PersonIndex]
         fields = ["firstname", "lastname", "full_name"]


### PR DESCRIPTION
(AN: my misinterpretation of this one line cost me at least 4 hours in debugging time. I'd love to spare others from my fate!)

By calling the serializer PersonSerializer, there's an implicit assumption made by the user that this is the same serializer that should govern the list/detail views (if they exist) of the Person model, but this clearly isn't the case.

By changing the name of the serializer to PersonSearchSerializer (as a tutorial I found did), it becomes immediately clear that the Haystack serializer is not supposed to be the same serializer as the serializer for the model throughout the rest of the API.