### PR TITLE
fix for autocomplete filter with OR field values

### DIFF
--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -244,6 +244,11 @@ class HaystackAutocompleteFilterTestCase(TestCase):
         response = self.view.as_view(actions={"get": "list"})(request)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    def test_filter_autocomplete_non_autocomplete_field_OR(self):
+        request = factory.get(path="/", data={"autocomplete": "jer", "first_name": "Hickman,Hood"}, content_type="application/json")
+        response = self.view.as_view(actions={"get": "list"})(request)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 @skipIf(not geospatial_support, "Skipped due to lack of GEO spatial features")
 class HaystackGEOSpatialFilterTestCase(TestCase):


### PR DESCRIPTION
Currently when you are using the `HaystackAutocompleteFilter` and you also want to reduce the queryset based on fixed value filter fields like: `autocomplete=I_want_to_find_this&status=status_1,status_2` this fails with:
```
  File "/python2.7/site-packages/rest_framework/mixins.py", line 40, in list
    queryset = self.filter_queryset(self.get_queryset())
  File "/python2.7/site-packages/drf_haystack/generics.py", line 82, in filter_queryset
    queryset = super(HaystackGenericAPIView, self).filter_queryset(queryset)
  File "/python2.7/site-packages/rest_framework/generics.py", line 151, in filter_queryset
    queryset = backend().filter_queryset(self.request, queryset, self)
  File "/python2.7/site-packages/drf_haystack/filters.py", line 125, in filter_queryset
    queryset = queryset.filter(self._construct_query(applicable_filters, queryset, view))
  File "/python2.7/site-packages/drf_haystack/filters.py", line 134, in _construct_query
    for field_name, query in filters.children:
TypeError: 'SQ' object is not iterable
```
filters.children: `[(u'autocomplete', u'I_want_to_find_this'), <SQ: OR (status__contains=status_1 OR status__contains=status_2)>]`

This PR fixes that. 

With this PR the resulting parsed filters are: `[<SQ: AND autocomplete__contains=I_want_to_find_this>, <SQ: OR (status__contains=status_1 OR status__contains=status_2)>]`

I think this is the expected behaviour.