### PR TITLE
actually implement declared field value methods on serializer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   elasticsearch:
     image: elasticsearch:1

--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -224,6 +224,12 @@ class HaystackSerializer(six.with_metaclass(HaystackSerializerMeta, serializers.
             prefix_field_names = len(getattr(self.Meta, "index_classes")) > 1
             current_index = self._get_index_class_name(type(instance.searchindex))
             for field in self.fields.keys():
+                # handle declared field value methods on serializer
+                value_method = getattr(self, "get_{0}".format(field), None)
+                if value_method and callable(value_method):
+                    ret[field] = value_method()
+
+                # now convert namespaced field names
                 orig_field = field
                 if prefix_field_names:
                     parts = field.split("__")

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -300,10 +300,13 @@ class HaystackSerializerMultipleIndexTestCase(WarningTestCaseMixin, TestCase):
         for result in data:
             if "name" in result:
                 assert "extra" in result, self.fail("'extra' should be present in Pet results")
+                self.assertEqual(result['extra'], 1, "The value of 'extra' should be 1")
                 assert "hair_color" not in result, self.fail("'hair_color' should not be present in Pet results")
             elif "lastname" in result:
                 assert "extra" in result, self.fail("'extra' should be present in Person results")
+                self.assertEqual(result['extra'], 1, "The value of 'extra' should be 1")
                 assert "hair_color" in result, self.fail("'hair_color' should be present in Person results")
+                self.assertEqual(result['hair_color'], 'black', "The value of 'hair_color' should be 'black'")
             else:
                 self.fail("Result should contain either Pet or Person fields")
 


### PR DESCRIPTION
This provides a fix for #99 

Turns out I just never even implemented the feature.  And the tests only checked for the presence of the fields, not their values.  That's also been fixed.