### PR TITLE
Fix the `_get_count` for DRF 3.8

### DIFF
--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -21,7 +21,6 @@ from haystack.utils import Highlighter
 
 from rest_framework import serializers
 from rest_framework.fields import empty
-from rest_framework.pagination import _get_count
 from rest_framework.utils.field_mapping import ClassLookupDict, get_field_kwargs
 
 from drf_haystack.fields import (
@@ -400,7 +399,7 @@ class HaystackFacetSerializer(six.with_metaclass(HaystackSerializerMeta, seriali
         if page is not None:
             serializer = view.get_facet_objects_serializer(page, many=True)
             return OrderedDict([
-                ("count", _get_count(queryset)),
+                ("count", self.get_count(queryset)),
                 ("next", view.paginator.get_next_link()),
                 ("previous", view.paginator.get_previous_link()),
                 ("results", serializer.data)
@@ -408,6 +407,15 @@ class HaystackFacetSerializer(six.with_metaclass(HaystackSerializerMeta, seriali
 
         serializer = view.get_serializer(queryset, many=True)
         return serializer.data
+
+    def get_count(self, queryset):
+        """
+        Determine an object count, supporting either querysets or regular lists.
+        """
+        try:
+            return queryset.count()
+        except (AttributeError, TypeError):
+            return len(queryset)
 
     @property
     def facet_query_params_text(self):


### PR DESCRIPTION
The `rest_framework.pagination._get_count` function [was removed](https://github.com/encode/django-rest-framework/commit/a7e2a7bfcdf9d10dd3f5c1061245f34a8e5227b6) in DRF 3.8. This patch moves this method to the `HaystackFacetSerializer` class.