### PR TITLE
feat: support SlugField

### DIFF
--- a/drf_haystack/serializers.py
+++ b/drf_haystack/serializers.py
@@ -137,6 +137,7 @@ class HaystackSerializer(six.with_metaclass(HaystackSerializerMeta, serializers.
                 "allow_blank",
                 "choices",
                 "model_field",
+                "allow_unicode",
             ]
             for attr in delete_attrs:
                 if attr in kwargs:


### PR DESCRIPTION
Adds support for SlugField by removing the `allow_unicode` parameter in the haystack field